### PR TITLE
Change GitHub Packages secret names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         --no-daemon
         --max-workers 2
         -Pkotlin.incremental=false
-        -Pgithub.packages.username=${{ secrets.GITHUB_PACKAGES_USERNAME }}
-        -Pgithub.packages.password=${{ secrets.GITHUB_PACKAGES_PASSWORD }}
+        -Pgithub.packages.username=${{ secrets.GH_PACKAGES_USERNAME }}
+        -Pgithub.packages.password=${{ secrets.GH_PACKAGES_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2-beta


### PR DESCRIPTION
It appears that GitHub no longer allows the `GITHUB_` prefix for [Secrets](https://github.com/JuulLabs/tuulbox/settings/secrets).

![Screen Shot 2020-05-07 at 10 24 17 AM](https://user-images.githubusercontent.com/98017/81325253-ee691600-904c-11ea-9e97-5e29ea341b2c.png)