### PR TITLE
JMP-637: Disable codecov/patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
+coverage:
+  status:
+    patch: off
 fixes:
   - "com/juul/tuulbox/collections::"


### PR DESCRIPTION
We found that `codecov/patch` check didn't add much value and just [created confusion](https://juullabs.slack.com/archives/GU0LX9HR9/p1588881867001600).