### PR TITLE
Add binary compatibility validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.71' apply false
     id 'org.jmailen.kotlinter' version '2.2.0' apply false
+    id 'binary-compatibility-validator' version '0.2.3'
 }
 
 subprojects {

--- a/collections/api/collections.api
+++ b/collections/api/collections.api
@@ -1,0 +1,30 @@
+public final class com/juul/tuulbox/collections/FlowConcurrentMap : java/util/concurrent/ConcurrentMap {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/concurrent/ConcurrentMap;)V
+	public fun clear ()V
+	public fun containsKey (Ljava/lang/Object;)Z
+	public fun containsValue (Ljava/lang/Object;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public final fun getOnChanged ()Lkotlinx/coroutines/flow/Flow;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putAll (Ljava/util/Map;)V
+	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public final fun size ()I
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class com/juul/tuulbox/collections/FlowConcurrentMapKt {
+	public static final fun withFlow (Ljava/util/concurrent/ConcurrentMap;)Lcom/juul/tuulbox/collections/FlowConcurrentMap;
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    resolutionStrategy {
+        eachPlugin {
+            // Support using `binary-compatibility-validator` via Gradle's plugin lambda.
+            // https://medium.com/@StefMa/its-time-to-ditch-the-buildscript-block-a1ab12e0d9ce
+            if (requested.id.id == "binary-compatibility-validator") {
+                useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
+            }
+        }
+    }
+}
+
 include ':collections'


### PR DESCRIPTION
Use [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) for validating binary compatibility between releases.

Piggybacks on `check` Gradle task (which was [already configured in the GitHub CI workflow](https://github.com/JuulLabs/tuulbox/blob/b65441119cfa851b6482af8f0a4ef756f6bbcc7c/.github/workflows/ci.yml#L38-L39)).