### PR TITLE
Setup Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+# https://github.com/release-drafter/release-drafter#configuration-options
+
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE (#$NUMBER)'
+
+template: $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners
 
 name: CI
-on: push
+on:
+  release:
+    types: [published]
+  push:
 
 jobs:
   build:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+# https://github.com/release-drafter/release-drafter#usage
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[Release Drafter](https://github.com/release-drafter/release-drafter) collects all the commits to the specified branch (`master` in this case) and drafts a **Release**.

It can be seen in action in project KoAP (where it's already been configured):

![release-drafter](https://user-images.githubusercontent.com/98017/85843825-a023e980-b756-11ea-9e7d-12f8d7fb453f.gif)