### PR TITLE
Native targets for Functional and Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Toolbox of utilities/helpers for Kotlin development.
 - [`logging`](logging) - Multiplatform logging library.  
 ![badge][badge-js]
 ![badge][badge-jvm]
+![badge][badge-mac]
 
 - [`functional`](functional) - Tools/utilities for manipulating functions  
 ![badge][badge-js]
 ![badge][badge-jvm]
+![badge][badge-mac]
 
 - [`test`](test) - Utilities for test suites  
 ![badge][badge-js]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
     kotlin("multiplatform") version "1.4.10" apply false
+    id("kotlinx-atomicfu") version "0.14.4" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
     id("net.mbonnin.one.eight") version "0.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,3 +5,8 @@ object kotlinx {
         version: String = "1.4.0"
     ) = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 }
+
+fun stately(
+    module: String,
+    version: String = "1.1.0-a1"
+) = "co.touchlab:stately-$module:$version"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,8 +5,3 @@ object kotlinx {
         version: String = "1.4.0"
     ) = "org.jetbrains.kotlinx:kotlinx-coroutines-$module:$version"
 }
-
-fun stately(
-    module: String,
-    version: String = "1.1.0-a1"
-) = "co.touchlab:stately-$module:$version"

--- a/functional/README.md
+++ b/functional/README.md
@@ -1,5 +1,6 @@
 ![badge-js]
 ![badge-jvm]
+![badge-mac]
 
 # Functional
 

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
 
     jvm()
     js().browser()
+    macosX64()
 
     sourceSets {
         val commonTest by getting {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 group=com.juul.tuulbox
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,5 +1,6 @@
 ![badge-js]
 ![badge-jvm]
+![badge-mac]
 
 # Logging
 

--- a/logging/api/logging.api
+++ b/logging/api/logging.api
@@ -18,6 +18,7 @@ public final class com/juul/tuulbox/logging/DispatchLogger : com/juul/tuulbox/lo
 	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun clear ()V
 	public fun debug (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun dispose ()V
 	public fun error (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun info (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun install (Lcom/juul/tuulbox/logging/Logger;)V

--- a/logging/api/logging.api
+++ b/logging/api/logging.api
@@ -18,7 +18,6 @@ public final class com/juul/tuulbox/logging/DispatchLogger : com/juul/tuulbox/lo
 	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun clear ()V
 	public fun debug (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public final fun dispose ()V
 	public fun error (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun info (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public final fun install (Lcom/juul/tuulbox/logging/Logger;)V
@@ -43,6 +42,10 @@ public final class com/juul/tuulbox/logging/Log {
 	public static synthetic fun verbose$default (Lcom/juul/tuulbox/logging/Log;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun warn (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun warn$default (Lcom/juul/tuulbox/logging/Log;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public synthetic class com/juul/tuulbox/logging/LogAtomicTagGeneratorRefVolatile {
+	public fun <init> (Ljava/lang/Object;)V
 }
 
 public abstract interface class com/juul/tuulbox/logging/Logger {

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
                 implementation(project(":test"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation(stately("isolate"))
             }
         }
 

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("multiplatform")
+    id("kotlinx-atomicfu")
     id("org.jmailen.kotlinter")
     jacoco
     `maven-publish`
@@ -16,17 +17,12 @@ kotlin {
     macosX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(stately("isolate"))
-            }
-        }
-
         val commonTest by getting {
             dependencies {
                 implementation(project(":test"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
+                implementation(stately("isolate"))
             }
         }
 

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -13,8 +13,15 @@ kotlin {
 
     jvm()
     js().browser()
+    macosX64()
 
     sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(stately("isolate"))
+            }
+        }
+
         val commonTest by getting {
             dependencies {
                 implementation(project(":test"))

--- a/logging/src/commonMain/kotlin/DispatchLogger.kt
+++ b/logging/src/commonMain/kotlin/DispatchLogger.kt
@@ -1,44 +1,51 @@
 package com.juul.tuulbox.logging
 
+import co.touchlab.stately.isolate.IsolateState
+
 /** Implementation of [Logger] which dispatches calls to consumer [Logger]s. */
 public class DispatchLogger : Logger {
-    private val consumers = mutableSetOf<Logger>()
+    private val consumers = IsolateState { mutableSetOf<Logger>() }
 
     /** `false` if no consumers have been installed, `true` if at least one consumer has been installed. */
     internal val hasConsumers: Boolean
-        get() = consumers.isNotEmpty()
+        get() = consumers.access { it.isNotEmpty() }
 
     /** Add a consumer to receive future dispatch calls. */
     public fun install(consumer: Logger) {
-        consumers.add(consumer)
+        consumers.access { it.add(consumer) }
     }
 
     /** Uninstall all installed consumers. */
     public fun clear() {
-        consumers.clear()
+        consumers.access { it.clear() }
+    }
+
+    /** Dispose of this dispatch logger when it is no longer needed. */
+    public fun dispose() {
+        consumers.dispose()
     }
 
     override fun verbose(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.verbose(tag, message, throwable) }
+        consumers.access { it.forEach { it.verbose(tag, message, throwable) } }
     }
 
     override fun debug(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.debug(tag, message, throwable) }
+        consumers.access { it.forEach { it.debug(tag, message, throwable) } }
     }
 
     override fun info(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.info(tag, message, throwable) }
+        consumers.access { it.forEach { it.info(tag, message, throwable) } }
     }
 
     override fun warn(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.warn(tag, message, throwable) }
+        consumers.access { it.forEach { it.warn(tag, message, throwable) } }
     }
 
     override fun error(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.error(tag, message, throwable) }
+        consumers.access { it.forEach { it.error(tag, message, throwable) } }
     }
 
     override fun assert(tag: String, message: String, throwable: Throwable?) {
-        consumers.forEach { it.assert(tag, message, throwable) }
+        consumers.access { it.forEach { it.assert(tag, message, throwable) } }
     }
 }

--- a/logging/src/commonMain/kotlin/Log.kt
+++ b/logging/src/commonMain/kotlin/Log.kt
@@ -1,6 +1,8 @@
 package com.juul.tuulbox.logging
 
-import kotlin.jvm.Volatile
+import co.touchlab.stately.isolate.IsolateState
+
+private class Reference<T: Any>(var value: T)
 
 /** Global logging object. To receive logs, call [dispatcher].[install][DispatchLogger.install]. */
 public object Log {
@@ -8,9 +10,14 @@ public object Log {
     /** Global log dispatcher. */
     public val dispatcher: DispatchLogger = DispatchLogger()
 
+    private val isolatedTagGenerator = IsolateState { Reference(defaultTagGenerator) }
+
     /** Global tag generator for log calls without explicit tag. */
-    @Volatile
-    public var tagGenerator: TagGenerator = defaultTagGenerator
+    public var tagGenerator: TagGenerator
+        get() = isolatedTagGenerator.access { it.value }
+        set(value) {
+            isolatedTagGenerator.access { it.value = value }
+        }
 
     /** Send a verbose-level log message to the global dispatcher. */
     public fun verbose(throwable: Throwable? = null, tag: String? = null, message: () -> String) {

--- a/logging/src/commonMain/kotlin/Log.kt
+++ b/logging/src/commonMain/kotlin/Log.kt
@@ -1,8 +1,6 @@
 package com.juul.tuulbox.logging
 
-import co.touchlab.stately.isolate.IsolateState
-
-private class Reference<T : Any>(var value: T)
+import kotlinx.atomicfu.atomic
 
 /** Global logging object. To receive logs, call [dispatcher].[install][DispatchLogger.install]. */
 public object Log {
@@ -10,13 +8,13 @@ public object Log {
     /** Global log dispatcher. */
     public val dispatcher: DispatchLogger = DispatchLogger()
 
-    private val isolatedTagGenerator = IsolateState { Reference(defaultTagGenerator) }
+    private val atomicTagGenerator = atomic(defaultTagGenerator)
 
     /** Global tag generator for log calls without explicit tag. */
     public var tagGenerator: TagGenerator
-        get() = isolatedTagGenerator.access { it.value }
+        get() = atomicTagGenerator.value
         set(value) {
-            isolatedTagGenerator.access { it.value = value }
+            atomicTagGenerator.value = value
         }
 
     /** Send a verbose-level log message to the global dispatcher. */

--- a/logging/src/commonMain/kotlin/Log.kt
+++ b/logging/src/commonMain/kotlin/Log.kt
@@ -2,7 +2,7 @@ package com.juul.tuulbox.logging
 
 import co.touchlab.stately.isolate.IsolateState
 
-private class Reference<T: Any>(var value: T)
+private class Reference<T : Any>(var value: T)
 
 /** Global logging object. To receive logs, call [dispatcher].[install][DispatchLogger.install]. */
 public object Log {

--- a/logging/src/commonTest/kotlin/CallListLogger.kt
+++ b/logging/src/commonTest/kotlin/CallListLogger.kt
@@ -1,46 +1,48 @@
 package com.juul.tuulbox.logging
 
+import co.touchlab.stately.isolate.IsolateState
+
 class CallListLogger : Logger {
 
-    private val mutableVerboseCalls = mutableListOf<Call>()
-    val verboseCalls: List<Call> = mutableVerboseCalls
+    private val mutableVerboseCalls = IsolateState { mutableListOf<Call>() }
+    val verboseCalls: List<Call> get() = mutableVerboseCalls.access { ArrayList(it) }
 
-    private val mutableDebugCalls = mutableListOf<Call>()
-    val debugCalls: List<Call> = mutableDebugCalls
+    private val mutableDebugCalls = IsolateState { mutableListOf<Call>() }
+    val debugCalls: List<Call> get() = mutableDebugCalls.access { ArrayList(it) }
 
-    private val mutableInfoCalls = mutableListOf<Call>()
-    val infoCalls: List<Call> = mutableInfoCalls
+    private val mutableInfoCalls = IsolateState { mutableListOf<Call>() }
+    val infoCalls: List<Call> get() = mutableInfoCalls.access { ArrayList(it) }
 
-    private val mutableWarnCalls = mutableListOf<Call>()
-    val warnCalls: List<Call> = mutableWarnCalls
+    private val mutableWarnCalls = IsolateState { mutableListOf<Call>() }
+    val warnCalls: List<Call> get() = mutableWarnCalls.access { ArrayList(it) }
 
-    private val mutableErrorCalls = mutableListOf<Call>()
-    val errorCalls: List<Call> = mutableErrorCalls
+    private val mutableErrorCalls = IsolateState { mutableListOf<Call>() }
+    val errorCalls: List<Call> get() = mutableErrorCalls.access { ArrayList(it) }
 
-    private val mutableAssertCalls = mutableListOf<Call>()
-    val assertCalls: List<Call> = mutableAssertCalls
+    private val mutableAssertCalls = IsolateState { mutableListOf<Call>() }
+    val assertCalls: List<Call> get() = mutableAssertCalls.access { ArrayList(it) }
 
     override fun verbose(tag: String, message: String, throwable: Throwable?) {
-        mutableVerboseCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableVerboseCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun debug(tag: String, message: String, throwable: Throwable?) {
-        mutableDebugCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableDebugCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun info(tag: String, message: String, throwable: Throwable?) {
-        mutableInfoCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableInfoCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun warn(tag: String, message: String, throwable: Throwable?) {
-        mutableWarnCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableWarnCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun error(tag: String, message: String, throwable: Throwable?) {
-        mutableErrorCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableErrorCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun assert(tag: String, message: String, throwable: Throwable?) {
-        mutableAssertCalls += Call(tag = tag, message = message, throwable = throwable)
+        mutableAssertCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
     }
 }

--- a/logging/src/commonTest/kotlin/CallListLogger.kt
+++ b/logging/src/commonTest/kotlin/CallListLogger.kt
@@ -1,48 +1,49 @@
 package com.juul.tuulbox.logging
 
-import co.touchlab.stately.isolate.IsolateState
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
 
 class CallListLogger : Logger {
 
-    private val mutableVerboseCalls = IsolateState { mutableListOf<Call>() }
-    val verboseCalls: List<Call> get() = mutableVerboseCalls.access { ArrayList(it) }
+    private val atomicVerboseCalls = atomic(emptyList<Call>())
+    val verboseCalls: List<Call> get() = atomicVerboseCalls.value
 
-    private val mutableDebugCalls = IsolateState { mutableListOf<Call>() }
-    val debugCalls: List<Call> get() = mutableDebugCalls.access { ArrayList(it) }
+    private val atomicDebugCalls = atomic(emptyList<Call>())
+    val debugCalls: List<Call> get() = atomicDebugCalls.value
 
-    private val mutableInfoCalls = IsolateState { mutableListOf<Call>() }
-    val infoCalls: List<Call> get() = mutableInfoCalls.access { ArrayList(it) }
+    private val atomicInfoCalls = atomic(emptyList<Call>())
+    val infoCalls: List<Call> get() = atomicInfoCalls.value
 
-    private val mutableWarnCalls = IsolateState { mutableListOf<Call>() }
-    val warnCalls: List<Call> get() = mutableWarnCalls.access { ArrayList(it) }
+    private val atomicWarnCalls = atomic(emptyList<Call>())
+    val warnCalls: List<Call> get() = atomicWarnCalls.value
 
-    private val mutableErrorCalls = IsolateState { mutableListOf<Call>() }
-    val errorCalls: List<Call> get() = mutableErrorCalls.access { ArrayList(it) }
+    private val atomicErrorCalls = atomic(emptyList<Call>())
+    val errorCalls: List<Call> get() = atomicErrorCalls.value
 
-    private val mutableAssertCalls = IsolateState { mutableListOf<Call>() }
-    val assertCalls: List<Call> get() = mutableAssertCalls.access { ArrayList(it) }
+    private val atomicAssertCalls = atomic(emptyList<Call>())
+    val assertCalls: List<Call> get() = atomicAssertCalls.value
 
     override fun verbose(tag: String, message: String, throwable: Throwable?) {
-        mutableVerboseCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicVerboseCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun debug(tag: String, message: String, throwable: Throwable?) {
-        mutableDebugCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicDebugCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun info(tag: String, message: String, throwable: Throwable?) {
-        mutableInfoCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicInfoCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun warn(tag: String, message: String, throwable: Throwable?) {
-        mutableWarnCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicWarnCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun error(tag: String, message: String, throwable: Throwable?) {
-        mutableErrorCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicErrorCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 
     override fun assert(tag: String, message: String, throwable: Throwable?) {
-        mutableAssertCalls.access { it += Call(tag = tag, message = message, throwable = throwable) }
+        atomicAssertCalls.getAndUpdate { it + Call(tag = tag, message = message, throwable = throwable) }
     }
 }

--- a/logging/src/macosX64Main/kotlin/ConsoleLogger.kt
+++ b/logging/src/macosX64Main/kotlin/ConsoleLogger.kt
@@ -1,0 +1,61 @@
+package com.juul.tuulbox.logging
+
+import com.juul.tuulbox.logging.ConsoleLogger.assert
+import com.juul.tuulbox.logging.ConsoleLogger.debug
+import com.juul.tuulbox.logging.ConsoleLogger.error
+import com.juul.tuulbox.logging.ConsoleLogger.info
+import com.juul.tuulbox.logging.ConsoleLogger.verbose
+import com.juul.tuulbox.logging.ConsoleLogger.warn
+import platform.posix.STDERR_FILENO
+import platform.posix.STDOUT_FILENO
+import platform.posix.fclose
+import platform.posix.fdopen
+import platform.posix.fflush
+import platform.posix.fprintf
+
+/**
+ * Logger for standard-out and standard-error.
+ *
+ * - Calls to [verbose], [debug], [info], and [warn] map to standard-out.
+ * - Calls to [error] and [assert] map to standard-error.
+ */
+public actual object ConsoleLogger : Logger {
+
+    private fun print(fileDescriptor: Int, severity: String, tag: String, message: String, throwable: Throwable?) {
+        val formattedString = if (throwable == null) {
+            "[$severity/$tag] $message\n"
+        } else {
+            "[$severity/$tag] $message: ${throwable.stackTraceToString()}\n"
+        }
+
+        // TODO: Opening the stream every log statement is slow.
+        val stream = checkNotNull(fdopen(fileDescriptor, "w")) { "Unable to open file descriptor $fileDescriptor" }
+        fprintf(stream, formattedString)
+        fflush(stream)
+        fclose(stream)
+    }
+
+    override fun verbose(tag: String, message: String, throwable: Throwable?) {
+        print(STDOUT_FILENO, "V", tag, message, throwable)
+    }
+
+    override fun debug(tag: String, message: String, throwable: Throwable?) {
+        print(STDOUT_FILENO, "D", tag, message, throwable)
+    }
+
+    override fun info(tag: String, message: String, throwable: Throwable?) {
+        print(STDOUT_FILENO, "I", tag, message, throwable)
+    }
+
+    override fun warn(tag: String, message: String, throwable: Throwable?) {
+        print(STDOUT_FILENO, "W", tag, message, throwable)
+    }
+
+    override fun error(tag: String, message: String, throwable: Throwable?) {
+        print(STDERR_FILENO, "E", tag, message, throwable)
+    }
+
+    override fun assert(tag: String, message: String, throwable: Throwable?) {
+        print(STDERR_FILENO, "A", tag, message, throwable)
+    }
+}

--- a/logging/src/macosX64Main/kotlin/DefaultTagGenerator.kt
+++ b/logging/src/macosX64Main/kotlin/DefaultTagGenerator.kt
@@ -1,0 +1,6 @@
+package com.juul.tuulbox.logging
+
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
+internal actual val defaultTagGenerator: TagGenerator = ConstantTagGenerator("Unknown")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,8 @@ pluginManagement {
         eachPlugin {
             if (requested.id.id == "binary-compatibility-validator") {
                 useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
+            } else if (requested.id.id == "kotlinx-atomicfu") {
+                useModule("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${requested.version}")
             }
         }
     }


### PR DESCRIPTION
# Functional
No changes, everything just worked.

# Logging
No `StackTraceTagGenerator` for now, not ruling it out for later. Hit two snags in my first stab:
- Instantiating a `Throwable` was setting off the memory-leak crash. I _think_ it was a false positive, but didn't want to spend too much time debugging, because...
- Stack traces in `Release` builds are super useless without the mapping file, which wouldn't be available at runtime. 

No console logger tests for now. In theory it should be possible to `freopen` the streams for `stdout` and `stderr`, but I had trouble getting that working.
- Verified instead by making a sample app that used them. 
- Looks like we don't run tests for OSX targets anyways in CI?