### PR TITLE
Add POM configuration for Maven publication

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,24 @@
-group=com.juul.tuulbox
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
+
+# Publication configuration
+# https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties
+
+GROUP=com.juul.tuulbox
+VERSION_NAME=main-SNAPSHOT
+
+POM_NAME=Tuulbox
+POM_DESCRIPTION=Toolbox of utilities/helpers for Kotlin development
+POM_INCEPTION_YEAR=2020
+
+POM_URL=https://github.com/JuulLabs/tuulbox
+POM_SCM_URL=https://github.com/JuulLabs/tuulbox
+POM_SCM_CONNECTION=scm:git:git://github.com/JuulLabs/tuulbox.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/JuulLabs/tuulbox.git
+
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=twyatt
+POM_DEVELOPER_NAME=Travis Wyatt
+POM_DEVELOPER_URL=https://github.com/twyatt


### PR DESCRIPTION
Oversight that this configuration wasn't included in #29.