### PR TITLE
Add missing configuration for Sonatype publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
     id("kotlinx-atomicfu") version "0.14.4" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
+    id("org.jetbrains.dokka") version "1.4.10.2" apply false
+    id("com.vanniktech.maven.publish") version "0.13.0" apply false
     id("net.mbonnin.one.eight") version "0.1"
 }
 

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -2,7 +2,8 @@ plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
     jacoco
-    `maven-publish`
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = rootProject.file("gradle/jacoco.gradle.kts"))

--- a/coroutines/gradle.properties
+++ b/coroutines/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=coroutines

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -2,7 +2,8 @@ plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
     jacoco
-    `maven-publish`
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = rootProject.file("gradle/jacoco.gradle.kts"))

--- a/functional/gradle.properties
+++ b/functional/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=functional

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
     id("kotlinx-atomicfu")
     id("org.jmailen.kotlinter")
     jacoco
-    `maven-publish`
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = rootProject.file("gradle/jacoco.gradle.kts"))

--- a/logging/gradle.properties
+++ b/logging/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=logging

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
-    `maven-publish`
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
 }
 
 apply(from = rootProject.file("gradle/publish.gradle.kts"))

--- a/test/gradle.properties
+++ b/test/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=test


### PR DESCRIPTION
Adds remaining configuration that is needed for Sonatype/Maven publication.
Was overlooked in both #29 and #30 (wups).