### PR TITLE
Remove 'version' Gradle variable check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,16 +39,3 @@ subprojects {
         }
     }
 }
-
-// Prevent publishing if `version` property is not set (e.g. via `-Pversion` command line argument).
-gradle.taskGraph.whenReady {
-    allTasks
-        .filter { task -> task.name.startsWith("publish") }
-        .forEach { task ->
-            task.doFirst {
-                if (!project.hasProperty("version") || project.findProperty("version") == "unspecified") {
-                    throw GradleException("Unable to publish without version property")
-                }
-            }
-        }
-}


### PR DESCRIPTION
Since transition to Sonatype / Maven publication in #29, #30 and #31, confirming `version` is no longer necessary. As publication requires signing and process is all performed on CI.