### PR TITLE
Bump Kotlin, atomicfu and Gradle wrapper versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.10" apply false
+    kotlin("multiplatform") version "1.4.31" apply false
     id("com.android.library") version "4.0.2" apply false
-    id("kotlinx-atomicfu") version "0.14.4" apply false
+    id("kotlinx-atomicfu") version "0.15.1" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
     id("org.jetbrains.dokka") version "1.4.10.2" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Jun 09 14:46:34 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Was receiving a strange failure in a downstream library, these version bumps seemed to resolve the issue.

```
<redacted>.DaemonTest[jvm] > Secret key is zeroed after use[jvm] FAILED
    java.lang.VerifyError: Bad type on operand stack in putfield
    Exception Details:
      Location:
        com/juul/tuulbox/logging/Log.setTagGenerator(Lcom/juul/tuulbox/logging/TagGenerator;)V @14: putfield
      Reason:
        Type 'com/juul/tuulbox/logging/TagGenerator' (current frame, stack[0]) is not assignable to 'com/juul/tuulbox/logging/LogAtomicTagGeneratorRefVolatile' (constant pool 27)
      Current Frame:
        bci: @14
        flags: { }
        locals: { 'com/juul/tuulbox/logging/Log', 'com/juul/tuulbox/logging/TagGenerator', '[Z' }
        stack: { 'com/juul/tuulbox/logging/TagGenerator', 'com/juul/tuulbox/logging/LogAtomicTagGeneratorRefVolatile' }
      Bytecode:
        0x0000000: b800 9b4d 2b12 21b8 0027 2bb2 0015 b500
        0x0000010: 1b2c 0504 54b1
        at <redacted>.suspendUntilConnected(Daemon.kt:201)
        at <redacted>.DaemonTest$Secret key is zeroed after use$1.invokeSuspend(DaemonTest.kt:215)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
        at <redacted>.DaemonTest.Secret key is zeroed after use(DaemonTest.kt:202)
```