### PR TITLE
Bump gradle-maven-publish-plugin version to fix publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
     id("org.jetbrains.dokka") version "1.4.10.2" apply false
-    id("com.vanniktech.maven.publish") version "0.13.0" apply false
+    id("com.vanniktech.maven.publish") version "0.14.0" apply false
     id("net.mbonnin.one.eight") version "0.1"
 }
 


### PR DESCRIPTION
Seeing the following failure when attempting to publish:

```
Execution failed for task ':functional:publishKotlinMultiplatformPublicationToLocalRepository'.
> Failed to publish publication 'kotlinMultiplatform' to repository 'local'
   > Invalid publication 'kotlinMultiplatform': multiple artifacts with the identical extension and classifier ('jar', 'sources').
```

As stated in [issue 185], bumping gradle-maven-publish-plugin to 0.14.0 resolves the issue.

[issue 185]: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/185#issuecomment-776973656