### PR TITLE
Setup publication of Dokka documentation to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,45 @@
+name: GitHub Pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+
+    env:
+      GRADLE_ARGS: >-
+        --no-daemon
+        --max-workers 2
+        -Pkotlin.incremental=false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gh-pages-
+            ${{ runner.os }}-
+
+      - name: Dokka
+        run: ./gradlew $GRADLE_ARGS dokkaHtmlMultiModule
+
+      - name: Deploy to Github Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          BRANCH: gh-pages
+          FOLDER: build/gh-pages

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-import java.net.URI
 
 buildscript {
     repositories {
@@ -14,23 +13,16 @@ plugins {
     id("kotlinx-atomicfu") version "0.15.1" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
-    id("org.jetbrains.dokka") version "1.4.10.2" apply false
+    id("org.jetbrains.dokka") version "1.4.30"
     id("com.vanniktech.maven.publish") version "0.14.0" apply false
     id("net.mbonnin.one.eight") version "0.1"
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         jcenter()
-        maven(url = "https://kotlin.bintray.com/kotlinx/")
-        maven {
-            url = URI("https://maven.pkg.github.com/juullabs/android-github-packages")
-            credentials {
-                username = findProperty("github.packages.username") as? String
-                password = findProperty("github.packages.password") as? String
-            }
-        }
+        maven("https://kotlin.bintray.com/kotlinx/")
     }
 
     tasks.withType<Test>().configureEach {
@@ -42,4 +34,8 @@ subprojects {
             showCauses = true
         }
     }
+}
+
+tasks.dokkaHtmlMultiModule.configure {
+    outputDirectory.set(buildDir.resolve("gh-pages"))
 }


### PR DESCRIPTION
Configured to publish updated Dokka documentation on every commit that is merged to `main`.