### PR TITLE
Install to Maven local for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,22 @@ jobs:
         if: runner.os == 'macOS'
         run: ./gradlew $GRADLE_ARGS macosX64Test
 
+      - name: Keyring (macOS)
+        if: runner.os == 'macOS'
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > "$HOME/secring.gpg"
+
+      - name: Publish Locally (macOS)
+        if: runner.os == 'macOS'
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          -PVERSION_NAME=unspecified
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+          installArchives
+
       - name: Assemble (Linux)
         if: runner.os == 'Linux'
         run: ./gradlew $GRADLE_ARGS assemble


### PR DESCRIPTION
Validates that project is ready for later Maven **Central** publication by performing a signed Maven **Local** installation during CI check.