### PR TITLE
Update Gradle properties used for publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,6 @@ jobs:
         run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
 
       - name: Publish
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
         run: >-
           ./gradlew
           $GRADLE_ARGS
@@ -52,4 +49,6 @@ jobs:
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
           -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+          -PmavenCentralRepositoryUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralRepositoryPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
           publish

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,8 @@
 name: Snapshot
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - main
 
 jobs:
   snapshot:
@@ -38,7 +39,11 @@ jobs:
         run: ./gradlew $GRADLE_ARGS check
 
       - name: Snapshot
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew $GRADLE_ARGS --no-parallel -PVERSION_NAME=main-SNAPSHOT publish
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          -PmavenCentralRepositoryUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralRepositoryPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          -PVERSION_NAME=main-SNAPSHOT
+          publish


### PR DESCRIPTION
Per messages seen during builds:

```
The env var SONATYPE_NEXUS_USERNAME is deprecated. Use the Gradle property mavenCentralRepositoryUsername or the env var ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername instead.
The env var SONATYPE_NEXUS_PASSWORD is deprecated. Use the Gradle property mavenCentralRepositoryPassword or the env var ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword instead.
```

---

Also fixed **Snapshot** Action (was using `$default-branch` which doesn't seem to work).