### PR TITLE
Expose mechanism to hide from stack trace 

### DIFF
--- a/logging/api/logging.api
+++ b/logging/api/logging.api
@@ -25,10 +25,13 @@ public final class com/juul/tuulbox/logging/DispatchLogger : com/juul/tuulbox/lo
 	public fun warn (Ljava/lang/String;Ljava/lang/String;Lcom/juul/tuulbox/logging/ReadMetadata;Ljava/lang/Throwable;)V
 }
 
+public abstract interface class com/juul/tuulbox/logging/HideFromStackTraceTag {
+}
+
 public abstract interface class com/juul/tuulbox/logging/Key {
 }
 
-public final class com/juul/tuulbox/logging/Log {
+public final class com/juul/tuulbox/logging/Log : com/juul/tuulbox/logging/HideFromStackTraceTag {
 	public static final field INSTANCE Lcom/juul/tuulbox/logging/Log;
 	public final fun assert (Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun assert$default (Lcom/juul/tuulbox/logging/Log;Ljava/lang/Throwable;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/logging/src/commonMain/kotlin/HideFromStackTraceTag.kt
+++ b/logging/src/commonMain/kotlin/HideFromStackTraceTag.kt
@@ -1,0 +1,7 @@
+package com.juul.tuulbox.logging
+
+/**
+ * Marker interface to skip a class in the stack trace for the default [TagGenerator] on JVM. On
+ * other targets, this interface does nothing.
+ */
+public interface HideFromStackTraceTag

--- a/logging/src/commonMain/kotlin/Log.kt
+++ b/logging/src/commonMain/kotlin/Log.kt
@@ -8,7 +8,7 @@ import kotlin.native.concurrent.ThreadLocal
 private val metadataPool = Pool(factory = ::Metadata, refurbish = Metadata::clear)
 
 /** Global logging object. To receive logs, call [dispatcher].[install][DispatchLogger.install]. */
-public object Log {
+public object Log : HideFromStackTraceTag {
 
     /** Global log dispatcher. */
     public val dispatcher: DispatchLogger = DispatchLogger()

--- a/logging/src/jsMain/kotlin/StackTraceTagGenerator.kt
+++ b/logging/src/jsMain/kotlin/StackTraceTagGenerator.kt
@@ -2,7 +2,7 @@ package com.juul.tuulbox.logging
 
 internal actual val defaultTagGenerator: TagGenerator = StackTraceTagGenerator
 
-internal object StackTraceTagGenerator : TagGenerator {
+internal object StackTraceTagGenerator : TagGenerator, HideFromStackTraceTag {
 
     /**
      * Matches a line of stacktrace output (except the first line).
@@ -13,6 +13,7 @@ internal object StackTraceTagGenerator : TagGenerator {
     private val stackTraceLineMatcher = Regex("""^\s{4}at (\w+)\..*$""")
 
     override fun getTag(): String {
+        // FIXME: This should implement support for [HideFromStackTrace] instead of hard-coding a known depth
         val line = Throwable().stackTraceToString().lineSequence()
             .drop(3)
             .first()

--- a/logging/src/jvmMain/kotlin/StackTraceTagGenerator.kt
+++ b/logging/src/jvmMain/kotlin/StackTraceTagGenerator.kt
@@ -10,7 +10,7 @@ internal object StackTraceTagGenerator : TagGenerator, HideFromStackTraceTag {
     override fun getTag(): String {
         val tagCandidate = Throwable().stackTrace.asSequence()
             .map { Class.forName(it.className) }
-            .first { !ignoreSubclassesOf.isAssignableFrom(it)}
+            .first { !ignoreSubclassesOf.isAssignableFrom(it) }
             .name
             .substringAfterLast('.')
         // This bit of logic is stolen from Timber, so use of Java's Pattern/Matcher

--- a/logging/src/jvmMain/kotlin/StackTraceTagGenerator.kt
+++ b/logging/src/jvmMain/kotlin/StackTraceTagGenerator.kt
@@ -2,18 +2,16 @@ package com.juul.tuulbox.logging
 
 internal actual val defaultTagGenerator: TagGenerator = StackTraceTagGenerator
 
-internal object StackTraceTagGenerator : TagGenerator {
+internal object StackTraceTagGenerator : TagGenerator, HideFromStackTraceTag {
     private val anonymousClassPattern = Regex("""(\$\d+)$""").toPattern()
 
-    private val ignoreClasses = setOf(
-        Log::class.java.name,
-        StackTraceTagGenerator::class.java.name
-    )
+    private val ignoreSubclassesOf = HideFromStackTraceTag::class.java
 
     override fun getTag(): String {
-        val tagCandidate = Throwable().stackTrace
-            .first { it.className !in ignoreClasses }
-            .className
+        val tagCandidate = Throwable().stackTrace.asSequence()
+            .map { Class.forName(it.className) }
+            .first { !ignoreSubclassesOf.isAssignableFrom(it)}
+            .name
             .substringAfterLast('.')
         // This bit of logic is stolen from Timber, so use of Java's Pattern/Matcher
         // instead of Kotlin's Regex is to guarantee exact behavior match.

--- a/logging/src/jvmTest/kotlin/StackTraceTagGeneratorTests.kt
+++ b/logging/src/jvmTest/kotlin/StackTraceTagGeneratorTests.kt
@@ -26,4 +26,12 @@ class StackTraceTagGeneratorTests {
             .substringBefore("$1")
         assertEquals(expected, supplier.get())
     }
+
+    @Test
+    fun tagIgnoreClassesMarkedWithHide() {
+        class HiddenClass : HideFromStackTraceTag {
+            fun getTag() = StackTraceTagGenerator.getTag()
+        }
+        assertEquals(StackTraceTagGeneratorTests::class.java.simpleName, HiddenClass().getTag())
+    }
 }


### PR DESCRIPTION
Exposes a mechanism to hide a class from the automatic tag stack trace on JVM. As an example of where this is useful, a library might make a custom `Log` object that automatically adds metadata to every call. By providing this interface, doing so will not come at the cost of ruining the tag associated with the call.