### PR TITLE
Use `pull_request` trigger for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  push:
+  pull_request:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"


### PR DESCRIPTION
Switch to `pull_request` trigger to support PRs from forks, essentially enables the following GitHub UI for forked PRs:

![Screen Shot 2021-07-15 at 4 16 16 PM](https://user-images.githubusercontent.com/98017/125870508-0b5c42b5-7d0b-4963-b173-499a509cf259.png)
