### PR TITLE
Add Gradle `wrapper-validation-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt-hotspot"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt-hotspot"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt-hotspot"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,6 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt-hotspot"


### PR DESCRIPTION
Safety measure against potential bad actors on forked PRs.

_(allows for external contributors to bump our Gradle wrapper version, if needed, and we can be confident it is changed to an official wrapper)_