### PR TITLE
Add Apple System Log Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Log.dispatcher.install(ConsoleLogger)
 
 Custom loggers can be created by implementing the [`Logger`] interface.
 
+#### Apple (NSLog)
+
+Log to the Apple System Log by installing the `AppleSystemLogger`.
+
+```kotlin
+Log.dispatcher.install(AppleSystemLogger)
+```
+
 ### Log
 
 Log message can be logged via:

--- a/logging/src/appleMain/kotlin/AppleSystemLogger.kt
+++ b/logging/src/appleMain/kotlin/AppleSystemLogger.kt
@@ -1,0 +1,38 @@
+package com.juul.tuulbox.logging
+
+import platform.Foundation.NSLog
+
+public object AppleSystemLogger : Logger {
+
+    override fun verbose(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("V", tag, message, throwable)
+    }
+
+    override fun debug(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("D", tag, message, throwable)
+    }
+
+    override fun info(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("I", tag, message, throwable)
+    }
+
+    override fun warn(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("W", tag, message, throwable)
+    }
+
+    override fun error(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("E", tag, message, throwable)
+    }
+
+    override fun assert(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        log("A", tag, message, throwable)
+    }
+
+    private fun log(level: String, tag: String, message: String, throwable: Throwable?) {
+        if (throwable == null) {
+            NSLog("%s/%s: %s", level, tag, message)
+        } else {
+            NSLog("%s/%s: %s\n%s", level, tag, message, throwable.stackTraceToString())
+        }
+    }
+}


### PR DESCRIPTION
Relates to #73. Not as good as `os_log`, but better than the console for many use cases.