### PR TITLE
Map To Javascript Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ limitations under the License.
 
 [Collections]: https://kotlinlang.org/docs/reference/collections-overview.html
 [`SynchronizedMap`]: https://juullabs.github.io/tuulbox/collections/collections/com.juul.tuulbox.collections/-synchronized-map/index.html 
+[`Map.toJsObject`]: https://juullabs.github.io/tuulbox/collections/collections/com.juul.tuulbox.collections/to-js-object.html
 [Coroutines]: https://kotlinlang.org/docs/reference/coroutines-overview.html
 [KotlinX DateTime]: https://github.com/Kotlin/kotlinx-datetime
 [core library desugaring]: https://developer.android.com/studio/write/java8-support#library-desugaring

--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ val map = SynchronizedMap(mutableMapOf("key" to "value"))
 val value = map.synchronized { getOrPut("key") { "defaultValue" } }
 ```
 
+### [`Map.toJsObject`]
+
+Convert a map to a Plain Old JavaScript Object by transforming the keys to strings and the values to any of the JavaScript types.
+
+`Map` is not directly accessible from Javascript code. For example:
+```kotlin
+val simple = mapOf(1 to "a")
+val json = js("JSON.stringify(simple)") as String
+println(json)
+>>>
+{
+  "_keys_up5z3z$_0": null,
+  "_values_6nw1f1$_0": null,
+  <and lots of other name-mangled properties>
+}
+
+val value = js("simple['1']") as String
+println(value)
+>>> ClassCastException: Illegal cast
+```
+
+Using this convertor to emit `Object` with the expected properties:
+```kotlin
+val simple = mapOf(1 to "a").toJsObject { it.key.toString() to it.value }
+val json = js("JSON.stringify(simple)") as String
+println(json)
+>>> {"1":"a"}
+
+val value = js("simple['1']") as String
+println(value)
+>>> a
+```
+
 ## [Coroutines](https://juullabs.github.io/tuulbox/coroutines/index.html)
 
 ![badge-android]

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,3 +30,12 @@ object ktor {
         version: String = VERSION
     ) = "io.ktor:ktor-server-$module:$version"
 }
+
+/** https://github.com/JetBrains/kotlin-wrappers */
+object wrappers {
+    private const val groupId = "org.jetbrains.kotlin-wrappers"
+
+    fun extensions(
+        version: String = "1.0.1-pre.245-kotlin-1.5.30"
+    ) = "$groupId:kotlin-extensions:$version"
+}

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -35,6 +35,12 @@ kotlin {
             }
         }
 
+        val jsMain by getting {
+            dependencies {
+                implementation(wrappers.extensions())
+            }
+        }
+
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))

--- a/collections/src/jsMain/kotlin/PojoMap.kt
+++ b/collections/src/jsMain/kotlin/PojoMap.kt
@@ -1,0 +1,39 @@
+package com.juul.tuulbox.collections
+
+import kotlinext.js.Object
+import kotlinext.js.PropertyDescriptor
+import kotlinext.js.jsObject
+
+/**
+ * Convert a map to a Plain Old JavaScript Object by transforming the keys to strings and the values
+ * to any of the JavaScript types.
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#javascript_types
+ *
+ * @param transform called on each entry to effect a mapping to a JavaScript Object. This function
+ *                  must convert the key to a string as Javascript Object keys are always strings.
+ *                  The value may be converted to an appropriate type as required.
+ */
+public fun <K, V> Map<K, V>.toJsObject(
+    transform: (Map.Entry<K, V>) -> Pair<String, Any>
+): Object {
+    val pojo = jsObject<Object>()
+    for (entry in this) {
+        val (key, value) = transform(entry)
+        pojo.setProperty(key, value)
+    }
+    return pojo
+}
+
+private fun Object.setProperty(name: String, value: Any) {
+    Object.defineProperty<Any, dynamic>(
+        o = this,
+        p = name,
+        attributes = propertyDescriptor(value)
+    )
+}
+
+private fun propertyDescriptor(value: Any): PropertyDescriptor<Any> =
+    jsObject {
+        this.enumerable = true
+        this.value = value
+    }

--- a/collections/src/jsTest/kotlin/PojoMapTest.kt
+++ b/collections/src/jsTest/kotlin/PojoMapTest.kt
@@ -1,0 +1,78 @@
+import com.juul.tuulbox.collections.toJsObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PojoMapTest {
+
+    @Test
+    fun toJsObject_whenEmpty_isEmpty() {
+        val pojo = emptyMap<String, Int>().toJsObject { it.key to it.value }
+        val keys = js("Object.keys(pojo)") as Array<String>
+        assertEquals(
+            expected = 0,
+            actual = keys.size,
+        )
+    }
+
+    @Test
+    fun toJsObject_withMultipleEntries_hasKeys() {
+        val pojo = mapOf(
+            "fortyTwo" to 42,
+            "sixtyNine" to 69,
+        ).toJsObject { it.key to it.value }
+        val keys = js("Object.keys(pojo)") as Array<String>
+        assertEquals(
+            expected = listOf("fortyTwo", "sixtyNine"),
+            actual = keys.toList(),
+        )
+    }
+
+    @Test
+    fun toJsObject_withMultipleEntries_hasValues() {
+        val pojo = mapOf(
+            "fortyTwo" to 42,
+            "sixtyNine" to 69,
+        ).toJsObject { it.key to it.value }
+        val values = js("Object.values(pojo)") as Array<Int>
+        assertEquals(
+            expected = listOf(42, 69),
+            actual = values.toList(),
+        )
+    }
+
+    @Test
+    fun toJsObject_withStringNumberPair_stringifiesToSimpleJson() {
+        val pojo = mapOf(
+            "fortyTwo" to 42,
+        ).toJsObject { it.key to it.value }
+        val json = js("JSON.stringify(pojo)") as String
+        assertEquals(
+            expected = "{\"fortyTwo\":42}",
+            actual = json,
+        )
+    }
+
+    @Test
+    fun toJsObject_withNumberStringPair_stringifiesToSimpleJson() {
+        val pojo = mapOf(
+            42 to "fortyTwo",
+        ).toJsObject { it.key.toString() to it.value }
+        val json = js("JSON.stringify(pojo)") as String
+        assertEquals(
+            expected = "{\"42\":\"fortyTwo\"}",
+            actual = json,
+        )
+    }
+
+    @Test
+    fun toJsObject_withArrayValue_stringifiesToSimpleJson() {
+        val pojo = mapOf(
+            "data" to listOf(1, 2, 3),
+        ).toJsObject { it.key to it.value.toTypedArray() }
+        val json = js("JSON.stringify(pojo)") as String
+        assertEquals(
+            expected = "{\"data\":[1,2,3]}",
+            actual = json,
+        )
+    }
+}


### PR DESCRIPTION
Adds `Map.toJsObject()` as a convenience for converting maps into Plain Old Javascript Objects for native consumption by Javascript code.

`Map` is not very accessible from Javascript code. For example:
```kotlin
val simple = mapOf(1 to "a")
val json = js("JSON.stringify(simple)") as String
println(json)
>>> {"_keys_up5z3z$_0":null,"_values_6nw1f1$_0":null,"_keys_qe2m0n$_0":null,"_values_kxdlqh$_0":null,"internalMap_uxhen5$_0":{"equality_mamlu8$_0":{},"backingMap_0":{"1":{"key_5xhq3d$_0":1,"_value_0":"a"}},"size_x3bm7r$_0":1},"equality_vgh6cm$_0":{},"_entries_7ih87x$_0":null}

val value = js("simple['1']") as String
println(value)
>>> ClassCastException: Illegal cast
```

Using this convertor to emit `Object` with the expected properties:
```kotlin
val simple = mapOf(1 to "a").toJsObject { it.key.toString() to it.value }
val json = js("JSON.stringify(simple)") as String
println(json)
>>> {"1":"a"}

val value = js("simple['1']") as String
println(value)
>>> a
```