### PR TITLE
Add `collections` to platform-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ repositories {
 }
 
 dependencies {
+    implementation("com.juul.tuulbox:collections:$version")
     implementation("com.juul.tuulbox:coroutines:$version")
     implementation("com.juul.tuulbox:logging:$version")
     implementation("com.juul.tuulbox:functional:$version")


### PR DESCRIPTION
Gradle `collections` setup line was missing in [platform-specific instructions](https://github.com/JuulLabs/tuulbox/tree/twyatt/collections#platform-specific).