### PR TITLE
Reduce Android minimum SDK to 16

### DIFF
--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -85,10 +85,10 @@ kotlin {
 }
 
 android {
-    compileSdkVersion(libs.versions.android.compile.get())
+    compileSdk = libs.versions.android.compile.get().toInt()
 
     defaultConfig {
-        minSdkVersion(libs.versions.android.min.get())
+        minSdk = 16
     }
 
     lintOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
-android-compile = "android-31"
-android-min = "24"
+android-compile = "31"
 coroutines = "1.6.0"
 coroutines-native = "1.6.0-native-mt!!"
 jacoco = "0.8.7"

--- a/logging-android/build.gradle.kts
+++ b/logging-android/build.gradle.kts
@@ -23,10 +23,10 @@ kotlin {
 }
 
 android {
-    compileSdkVersion(libs.versions.android.compile.get())
+    compileSdk = libs.versions.android.compile.get().toInt()
 
     defaultConfig {
-        minSdkVersion(libs.versions.android.min.get())
+        minSdk = 16
     }
 
     lintOptions {

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -73,10 +73,10 @@ kotlin {
 }
 
 android {
-    compileSdkVersion(libs.versions.android.compile.get())
+    compileSdk = libs.versions.android.compile.get().toInt()
 
     defaultConfig {
-        minSdkVersion(libs.versions.android.min.get())
+        minSdk = 16
     }
 
     lintOptions {


### PR DESCRIPTION
Minimum SDK of 16 was chosen as it is supported by 100% of devices (according to the **New Project Wizard**) and still provides us with a reasonable Android API (we can always bump as needed):

![Screen Shot 2022-01-12 at 3 08 11 PM](https://user-images.githubusercontent.com/98017/149237524-24f3d48c-83ef-4a6a-a8b9-cb6f1025e017.png)

<details>
<summary>API Version Distribution</summary>

![Screen Shot 2022-01-12 at 3 08 21 PM](https://user-images.githubusercontent.com/98017/149237572-0cce2e31-1fa3-4da1-8361-239f4cb18f46.png)
</details>

Additionally, made it so that `minSdk` is configured per module, as in the future: when a module wants to use an API in a newer Android SDK, it doesn't need to effect the other modules.