### PR TITLE
Fix base64 encoding of bytes with MSB set

### DIFF
--- a/encoding/src/commonMain/kotlin/Base64.kt
+++ b/encoding/src/commonMain/kotlin/Base64.kt
@@ -101,7 +101,7 @@ private fun Iterator<Byte>.encodeBase64(): String {
     var bufferBits = 0
     while (hasNext()) {
         if (bufferBits < 6) {
-            buffer = (buffer shl 8) or next().toInt()
+            buffer = (buffer shl 8) or next().toUByte().toInt()
             index += 1
             bufferBits += 8
         }

--- a/encoding/src/commonTest/kotlin/Base64Tests.kt
+++ b/encoding/src/commonTest/kotlin/Base64Tests.kt
@@ -58,4 +58,14 @@ class Base64Tests {
             assertEquals(expected, input.encodeToByteArray().encodeBase64())
         }
     }
+
+    @Test
+    fun encodeBase64_byteArrayWithMsbSet_encodesWithoutException() {
+        // gzip of the string '["a","b","c"]'
+        val data = byteArrayOf(31, -117, 8, 0, 0, 0, 0, 0, 0, 0, -117, 86, 74, 84, -46, 81, 74, 2, -30, 100, -91, 88, 0, -17, 71, -25, -80, 13, 0, 0, 0)
+        assertEquals(
+            expected = "H4sIAAAAAAAAAItWSlTSUUoC4mSlWADvR+ewDQAAAA==",
+            actual = data.encodeBase64()
+        )
+    }
 }


### PR DESCRIPTION
Fixes failure that would occur when attempting to encode data that included bytes with their MSB set.

For example, attempting to encode the following bytes:
```
1f 8b 08 00 00 00 00 00 00 00 8b 56 4a 54 d2 51 4a 02 e2 64 a5 58 00 ef 47 e7 b0 0d 00 00 00
```

Would fail with:

```
Cannot encode more than 6 bits. Received `-1000`.
java.lang.IllegalStateException: Cannot encode more than 6 bits. Received `-1000`.
	at com.juul.tuulbox.encoding.Base64Kt.encode(Base64.kt:90)
	at com.juul.tuulbox.encoding.Base64Kt.encodeBase64(Base64.kt:110)
	at com.juul.tuulbox.encoding.Base64Kt.encodeBase64(Base64.kt:93)
        ..
```