### PR TITLE
Add basic support for parsing hex from `CharSequence`

### DIFF
--- a/encoding/api/encoding.api
+++ b/encoding/api/encoding.api
@@ -18,6 +18,7 @@ public final class com/juul/tuulbox/encoding/BitSetKt {
 }
 
 public final class com/juul/tuulbox/encoding/HexStringKt {
+	public static final fun parseHex (Ljava/lang/CharSequence;)[B
 	public static final fun toHexString ([BLjava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
 	public static synthetic fun toHexString$default ([BLjava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
 }

--- a/encoding/src/commonMain/kotlin/HexString.kt
+++ b/encoding/src/commonMain/kotlin/HexString.kt
@@ -21,3 +21,29 @@ public fun ByteArray.toHexString(
     }
     return r.toString()
 }
+
+/**
+ * Provides basic hex [CharSequence] to [ByteArray] conversion. Modified version of kotlinx.serialization's `HexConverter`:
+ * https://github.com/Kotlin/kotlinx.serialization/blob/43d5f7841fc744b072a636b712e194081456b5ba/formats/cbor/commonTest/src/kotlinx/serialization/HexConverter.kt
+ */
+public fun CharSequence.parseHex(): ByteArray {
+    if (isEmpty()) return byteArrayOf()
+    require(length % 2 == 0) { "Hex sequence must contain an even number of characters" }
+    val bytes = ByteArray(length / 2)
+    var i = 0
+    while (i < length) {
+        val h = hexToInt(this[i])
+        val l = hexToInt(this[i + 1])
+        require(!(h == -1 || l == -1)) { "Invalid hex characters '${this[i]}${this[i + 1]}' at $i" }
+        bytes[i / 2] = ((h shl 4) + l).toByte()
+        i += 2
+    }
+    return bytes
+}
+
+private fun hexToInt(ch: Char): Int = when (ch) {
+    in '0'..'9' -> ch - '0'
+    in 'A'..'F' -> ch - 'A' + 10
+    in 'a'..'f' -> ch - 'a' + 10
+    else -> -1
+}

--- a/encoding/src/commonMain/kotlin/HexString.kt
+++ b/encoding/src/commonMain/kotlin/HexString.kt
@@ -30,13 +30,11 @@ public fun CharSequence.parseHex(): ByteArray {
     if (isEmpty()) return byteArrayOf()
     require(length % 2 == 0) { "Hex sequence must contain an even number of characters" }
     val bytes = ByteArray(length / 2)
-    var i = 0
-    while (i < length) {
+    for (i in 0 until length step 2) {
         val h = hexToInt(this[i])
         val l = hexToInt(this[i + 1])
         require(!(h == -1 || l == -1)) { "Invalid hex characters '${this[i]}${this[i + 1]}' at $i" }
         bytes[i / 2] = ((h shl 4) + l).toByte()
-        i += 2
     }
     return bytes
 }

--- a/encoding/src/commonTest/kotlin/HexStringTest.kt
+++ b/encoding/src/commonTest/kotlin/HexStringTest.kt
@@ -1,6 +1,7 @@
 package com.juul.tuulbox.encoding
 
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
@@ -50,33 +51,33 @@ class HexStringTest {
 
     @Test
     fun parseHex() {
-        assertEquals(
-            expected = byteArrayOf(1, 2, 3).asList(),
-            actual = "010203".parseHex().asList(),
+        assertContentEquals(
+            expected = byteArrayOf(1, 2, 3),
+            actual = "010203".parseHex(),
         )
     }
 
     @Test
     fun parseHex_lowercaseHexCharacters() {
-        assertEquals(
-            expected = byteArrayOf(-54, -2).asList(),
-            actual = "cafe".parseHex().asList(),
+        assertContentEquals(
+            expected = byteArrayOf(-54, -2),
+            actual = "cafe".parseHex(),
         )
     }
 
     @Test
     fun parseHex_uppercaseHexCharacters() {
-        assertEquals(
-            expected = byteArrayOf(-54, -2).asList(),
-            actual = "CAFE".parseHex().asList(),
+        assertContentEquals(
+            expected = byteArrayOf(-54, -2),
+            actual = "CAFE".parseHex(),
         )
     }
 
     @Test
     fun parseHex_mixedCaseHexCharacters() {
-        assertEquals(
-            expected = byteArrayOf(-54, -2).asList(),
-            actual = "CaFe".parseHex().asList(),
+        assertContentEquals(
+            expected = byteArrayOf(-54, -2),
+            actual = "CaFe".parseHex(),
         )
     }
 

--- a/encoding/src/commonTest/kotlin/HexStringTest.kt
+++ b/encoding/src/commonTest/kotlin/HexStringTest.kt
@@ -2,6 +2,7 @@ package com.juul.tuulbox.encoding
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class HexStringTest {
 
@@ -45,5 +46,51 @@ class HexStringTest {
             expected = "0x01, 0x20, 0xa0, 0xff",
             actual = testBytes.toHexString(separator = ", ", prefix = "0x", lowerCase = true)
         )
+    }
+
+    @Test
+    fun parseHex() {
+        assertEquals(
+            expected = byteArrayOf(1, 2, 3).asList(),
+            actual = "010203".parseHex().asList(),
+        )
+    }
+
+    @Test
+    fun parseHex_lowercaseHexCharacters() {
+        assertEquals(
+            expected = byteArrayOf(-54, -2).asList(),
+            actual = "cafe".parseHex().asList(),
+        )
+    }
+
+    @Test
+    fun parseHex_uppercaseHexCharacters() {
+        assertEquals(
+            expected = byteArrayOf(-54, -2).asList(),
+            actual = "CAFE".parseHex().asList(),
+        )
+    }
+
+    @Test
+    fun parseHex_mixedCaseHexCharacters() {
+        assertEquals(
+            expected = byteArrayOf(-54, -2).asList(),
+            actual = "CaFe".parseHex().asList(),
+        )
+    }
+
+    @Test
+    fun parseHex_containsNonHexCharacter_throwsIllegalArgumentException() {
+        assertFailsWith<IllegalArgumentException> {
+            "hello".parseHex()
+        }
+    }
+
+    @Test
+    fun parseHex_incorrectLength_throwsIllegalArgumentException() {
+        assertFailsWith<IllegalArgumentException> {
+            "0102030".parseHex()
+        }
     }
 }


### PR DESCRIPTION
I was going to support `prefix` and `separator` (similar to its `toHexString` counterpart) but it made the implementation significantly more complex — decided to stick with this simple implementation that we can expand on in the future if needed. Library consumers can pre-process the `CharSequence` to remove any prefixes or separators, as desired.