### PR TITLE
Drop usage of explicit Webpack version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,4 @@ POM_DEVELOPER_ID=twyatt
 POM_DEVELOPER_NAME=Travis Wyatt
 POM_DEVELOPER_URL=https://github.com/twyatt
 
-kotlin.js.webpack.major.version=5
 kotlin.js.compiler=both


### PR DESCRIPTION
Rather than specifying a version, we should use the default.

Closes #155