### PR TITLE
Use official `runTest` in tests

### DIFF
--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":test"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/collections/src/jsTest/kotlin/PojoMapTest.kt
+++ b/collections/src/jsTest/kotlin/PojoMapTest.kt
@@ -1,4 +1,5 @@
-import com.juul.tuulbox.collections.toJsObject
+package com.juul.tuulbox.collections
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":test"))
+                implementation(libs.kotlinx.coroutines.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/coroutines/src/commonTest/kotlin/delay/DelayStrategyTest.kt
+++ b/coroutines/src/commonTest/kotlin/delay/DelayStrategyTest.kt
@@ -1,11 +1,12 @@
 package com.juul.tuulbox.coroutines.delay
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -54,7 +55,7 @@ class DelayStrategyTest {
     }
 
     @Test
-    @OptIn(ExperimentalTime::class)
+    @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
     fun dynamicDelayStrategy_switchesBetweenStrategies_usingTrigger() = runTest {
         val trigger = MutableStateFlow(true)
         val timeMachine = TimeMachine()

--- a/coroutines/src/commonTest/kotlin/flow/CombineParametersTest.kt
+++ b/coroutines/src/commonTest/kotlin/flow/CombineParametersTest.kt
@@ -1,11 +1,13 @@
 package com.juul.tuulbox.coroutines.flow
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class CombineParametersTest {
 
     @Test

--- a/encoding/build.gradle.kts
+++ b/encoding/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     sourceSets {
         val commonTest by getting {
             dependencies {
-                implementation(project(":test"))
+                implementation(libs.kotlinx.coroutines.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":test"))
+                implementation(libs.kotlinx.coroutines.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/functional/src/commonTest/kotlin/ComposeTests.kt
+++ b/functional/src/commonTest/kotlin/ComposeTests.kt
@@ -1,10 +1,13 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ComposeTests {
+
     @Test
     fun checkOfOrderIsCorrect() = runTest {
         assertEquals(202, double.of(increment).invoke(100))

--- a/functional/src/commonTest/kotlin/CurryTests.kt
+++ b/functional/src/commonTest/kotlin/CurryTests.kt
@@ -1,10 +1,13 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class CurryTests {
+
     @Test
     fun checkCurryWorksWithArity2() = runTest {
         val expected = stringConcat2("one", "two")

--- a/functional/src/commonTest/kotlin/MemoizeTests.kt
+++ b/functional/src/commonTest/kotlin/MemoizeTests.kt
@@ -1,9 +1,11 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MemoizeTests {
 
     private class DuplicationChecker {

--- a/functional/src/commonTest/kotlin/PartialApplyTests.kt
+++ b/functional/src/commonTest/kotlin/PartialApplyTests.kt
@@ -1,12 +1,14 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PartialApplyTests {
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun checkPartialApply() = runTest {
         val expected = stringConcat6("first", "second", "third", "fourth", "fifth", "sixth")
         val actual = stringConcat6

--- a/functional/src/commonTest/kotlin/RepeatTests.kt
+++ b/functional/src/commonTest/kotlin/RepeatTests.kt
@@ -1,10 +1,12 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RepeatTests {
 
     @Test

--- a/functional/src/commonTest/kotlin/ReverseTests.kt
+++ b/functional/src/commonTest/kotlin/ReverseTests.kt
@@ -1,9 +1,11 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ReverseTests {
 
     @Test

--- a/functional/src/commonTest/kotlin/RotateTests.kt
+++ b/functional/src/commonTest/kotlin/RotateTests.kt
@@ -1,9 +1,11 @@
 package com.juul.tuulbox.functional
 
-import com.juul.tuulbox.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RotateTests {
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-native = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-native" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.3.2" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(project(":logging-test"))
-                implementation(project(":test"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
                 implementation(project(":test"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
 

--- a/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
+++ b/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
@@ -1,21 +1,19 @@
 package com.juul.tuulbox.temporal
 
 import com.juul.tuulbox.test.assertSimilar
-import com.juul.tuulbox.test.runTest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
-@ExperimentalTime
-private val EPSILON = Duration.seconds(5)
+private val EPSILON = 5.seconds
 
-@ExperimentalTime
+@OptIn(ExperimentalTime::class)
 @AndroidIgnore("Cannot use Android classes BroadcastReceiver or IntentFilter.")
 class TemporalFlowTests {
 

--- a/temporal/src/commonTest/kotlin/TickerTests.kt
+++ b/temporal/src/commonTest/kotlin/TickerTests.kt
@@ -1,12 +1,12 @@
 package com.juul.tuulbox.temporal
 
-import com.juul.tuulbox.test.runTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
Was unable to migrate to official `runTest` in `logging-ktor-client` module, as pulling in `org.jetbrains.kotlinx:kotlinx-coroutines-test` pulls in non-`-native-mt` version of Coroutines which would result in:

<details>
<summary>Gradle task failure</summary>

```
> Task :logging-ktor-client:macosX64Test

com.juul.tuulbox.logging.TuulboxKtorClientLoggerTests.tuulboxlogger_atDefaultLevel_logsVerbose FAILED
    kotlin.native.concurrent.InvalidMutabilityException at /Users/teamcity3/buildAgent/work/c3a91df21e46e2c8/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Throwable.kt:24

com.juul.tuulbox.logging.TuulboxKtorClientLoggerTests.tuulboxlogger_atSpecificLevel_logsAtLevel FAILED
    kotlin.native.concurrent.InvalidMutabilityException at /Users/teamcity3/buildAgent/work/c3a91df21e46e2c8/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Throwable.kt:24

com.juul.tuulbox.logging.TuulboxKtorClientLoggerTests.tuulboxlogger_withMetadataCallback_installsMetadata FAILED
    kotlin.native.concurrent.InvalidMutabilityException at /Users/teamcity3/buildAgent/work/c3a91df21e46e2c8/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Throwable.kt:24
```
</details>

We can migrate `logging-ktor-client` module to use official `runTest` once we switch to using the new memory model.