### PR TITLE
Fix publish CI process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,10 @@ jobs:
             ${{ runner.os }}-publish-
             ${{ runner.os }}-
 
-      - run: ./gradlew check
+      # Enabled new memory model for tests to workaround `MockEngine` freezing issue (after upgrading to Ktor 2.0.0).
+      # https://github.com/JuulLabs/tuulbox/pull/168
+      - run: ./gradlew -Pkotlin.native.binary.memoryModel=experimental check
+
       - run: >-
           ./gradlew
           --no-parallel


### PR DESCRIPTION
Checks were [failing](https://github.com/JuulLabs/tuulbox/runs/7171089666?check_suite_focus=true) during publication. Was an oversight, that new memory model was enabled for CI but not publications.