### PR TITLE
Use Gradle type-safe project accessors

### DIFF
--- a/logging-android/build.gradle.kts
+++ b/logging-android/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":logging"))
+                api(projects.logging)
             }
         }
     }

--- a/logging-ktor-client/build.gradle.kts
+++ b/logging-ktor-client/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":logging"))
+                api(projects.logging)
                 api(libs.ktor.core)
                 api(libs.ktor.logging)
             }
@@ -32,8 +32,8 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":logging-test"))
-                implementation(project(":test"))
+                implementation(projects.loggingTest)
+                implementation(projects.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(libs.ktor.mock)

--- a/logging-test/build.gradle.kts
+++ b/logging-test/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":logging"))
+                api(projects.logging)
             }
         }
     }

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":logging-test"))
+                implementation(projects.loggingTest)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-enableFeaturePreview("VERSION_CATALOGS")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
-                implementation(project(":test"))
+                implementation(projects.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation(libs.kotlinx.coroutines.test)
@@ -49,7 +49,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(project(":coroutines"))
+                implementation(projects.coroutines)
             }
         }
 


### PR DESCRIPTION
Enables Gradle [type-safe project dependencies](https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors).

Special thanks to [Jake Wharton](https://twitter.com/JakeWharton/status/1491116447703375873?s=20&t=OSmqu1G4hGUUHSh2br5pSQ):

```zsh
find . -type f -name 'build.gradle*' -exec gsed -i -e "/project(/s/-[a-z]/\U&/g" -e "/project(/s/:/./g" -e "/project(/s/-//g" -E -e "s/project\((path\. ?)?('|\")([^'\"]+)\2\)/projects\3/" {} \;
```
