### PR TITLE
Update plugin atomicfu to v0.18.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "7.2.2" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.18.0" }
+atomicfu = { id = "kotlinx-atomicfu", version = "0.18.3" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.8.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.7.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
## [0.18.3](https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.18.3)
- Fix for atomicfu-gradle-plugin application to the MPP project (for Kotlin 1.7.20).

## [0.18.2](https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.18.2)
- In Kotlin 1.7.10 the name of atomicfu-runtime module was reverted back to kotlinx-atomicfu-runtime,
as the renaming was an incompatible change.
- Fixed atomicfu-gradle-plugin to add kotlinx-atomicfu-runtime dependency directly.

## [0.18.1](https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.18.1)
- Fix for the compatibility issue: add atomicfu-runtime dependency directly since Kotlin 1.7.10.