### PR TITLE
Remove Coroutines `native-mt` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,7 @@ jobs:
             ${{ runner.os }}-
 
       - run: ./gradlew assemble
-
-      # Enabled new memory model for tests to workaround `MockEngine` freezing issue (after upgrading to Ktor 2.0.0).
-      # https://github.com/JuulLabs/tuulbox/pull/168
-      - run: ./gradlew --continue -Pkotlin.native.binary.memoryModel=experimental check
+      - run: ./gradlew --continue check
 
       - run: |
           set -o xtrace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,7 @@ jobs:
             ${{ runner.os }}-publish-
             ${{ runner.os }}-
 
-      # Enabled new memory model for tests to workaround `MockEngine` freezing issue (after upgrading to Ktor 2.0.0).
-      # https://github.com/JuulLabs/tuulbox/pull/168
-      - run: ./gradlew -Pkotlin.native.binary.memoryModel=experimental check
+      - run: ./gradlew check
 
       - run: >-
           ./gradlew

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 android-compile = "31"
 coroutines = "1.6.4"
-coroutines-native = "1.6.1-native-mt!!"
 jacoco = "0.8.7"
 kotlin = "1.7.20"
 ktor = "2.1.3"
@@ -10,7 +9,6 @@ ktor = "2.1.3"
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlinx-coroutines-native = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-native" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/logging-ktor-client/build.gradle.kts
+++ b/logging-ktor-client/build.gradle.kts
@@ -58,9 +58,6 @@ kotlin {
 
         val appleTest by creating {
             dependsOn(commonTest)
-            dependencies {
-                implementation(libs.kotlinx.coroutines.native)
-            }
         }
 
         val macosX64Main by getting {


### PR DESCRIPTION
New memory model is enabled by default in current versions of Kotlin, so the `native-mt` versions of Coroutines should no longer be necessary.