### PR TITLE
Drop `LEGACY` JavaScript compiler support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
+kotlin.js.compiler=ir
 
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
@@ -34,5 +35,3 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=twyatt
 POM_DEVELOPER_NAME=Travis Wyatt
 POM_DEVELOPER_URL=https://github.com/twyatt
-
-kotlin.js.compiler=both


### PR DESCRIPTION
According to [KT-42289 comment](https://youtrack.jetbrains.com/issue/KT-42289/Make-the-new-JS-IR-backend-Stable#focus=Comments-27-6622643.0-0), Kotlin/JS IR backend is considered stable w/ 1.8.0, and legacy backend is now deprecated.