### PR TITLE
Upload test reports on failure as GitHub Actions artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       - run: ./gradlew assemble
       - run: ./gradlew --continue check
 
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test-failure
+          path: '**/build/reports/tests/'
+          retention-days: 5
+
       - run: |
           set -o xtrace
           if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           name: test-failure
           path: '**/build/reports/tests/'
+          retention-days: 5
 
       - run: |
           set -o xtrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           name: test-failure
           path: '**/build/reports/tests/'
-          retention-days: 5
 
       - run: |
           set -o xtrace

--- a/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
+++ b/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
@@ -22,6 +23,7 @@ class TemporalFlowTests {
         val expected = Clock.System.now()
         val actual = instantFlow().first()
         assertSimilar(expected, EPSILON, actual)
+        fail()
     }
 
     @Test

--- a/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
+++ b/temporal/src/commonTest/kotlin/TemporalFlowTests.kt
@@ -8,7 +8,6 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
@@ -23,7 +22,6 @@ class TemporalFlowTests {
         val expected = Clock.System.now()
         val actual = instantFlow().first()
         assertSimilar(expected, EPSILON, actual)
-        fail()
     }
 
     @Test


### PR DESCRIPTION
If a test fails, artifact for that run can be found at:

<img width="867" alt="Screen Shot 2023-04-06 at 11 25 12 AM" src="https://user-images.githubusercontent.com/98017/230464001-a6391e70-aaab-4cee-9466-969bf675cf18.png">