### PR TITLE
Use JDK 17 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false
-    alias(libs.plugins.one.eight)
     alias(libs.plugins.binary.compatibility.validator)
 }
 

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -11,6 +11,8 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
+
     jvm()
     js().browser()
     macosX64()

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -11,6 +11,8 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
+
     jvm()
     js().browser()
     android {
@@ -95,6 +97,13 @@ kotlin {
 }
 
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = 16
     

--- a/encoding/build.gradle.kts
+++ b/encoding/build.gradle.kts
@@ -10,6 +10,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -10,6 +10,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx2048m
 kotlin.js.compiler=ir
 
 # Android Configuration

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,4 +23,3 @@ binary-compatibility-validator = { id = "binary-compatibility-validator", versio
 dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.14.0" }
-one-eight = { id = "net.mbonnin.one.eight", version = "0.2" }

--- a/logging-android/build.gradle.kts
+++ b/logging-android/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     android {
         publishAllLibraryVariants()
@@ -23,6 +24,13 @@ kotlin {
 }
 
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = 16
 

--- a/logging-ktor-client/build.gradle.kts
+++ b/logging-ktor-client/build.gradle.kts
@@ -11,6 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()

--- a/logging-test/build.gradle.kts
+++ b/logging-test/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -11,6 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -11,6 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser {
@@ -74,6 +75,13 @@ kotlin {
 }
 
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = 16
 

--- a/temporal/src/androidMain/kotlin/BroadcastTemporalFlow.kt
+++ b/temporal/src/androidMain/kotlin/BroadcastTemporalFlow.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 @PublishedApi
-internal val temporalEventFilter = IntentFilter().apply {
+internal val temporalEventFilter: IntentFilter = IntentFilter().apply {
     addAction(Intent.ACTION_DATE_CHANGED)
     addAction(Intent.ACTION_TIME_CHANGED)
     addAction(Intent.ACTION_TIME_TICK)

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(11)
 
     jvm()
     js().browser()


### PR DESCRIPTION
Newer versions of AGP (see #260) require JDK 17:

```
An exception occurred applying plugin request [id: 'com.android.library', artifact: 'com.android.tools.build:gradle:null']
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.18-10/x64/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```