### PR TITLE
Fix determination of minimum log level for dispatch logger

### DIFF
--- a/logging/src/commonMain/kotlin/DispatchLogger.kt
+++ b/logging/src/commonMain/kotlin/DispatchLogger.kt
@@ -9,7 +9,7 @@ private data class DispatcherState(
     val consumers: Set<Logger>,
 ) {
     val logLevel: LogLevel by lazy {
-        consumers.maxOfOrNull { it.minimumLogLevel }
+        consumers.minOfOrNull { it.minimumLogLevel }
             ?: LogLevel.Assert
     }
 }


### PR DESCRIPTION
The minimum log level when multiple loggers were installed was incorrectly determined to be the max level of all loggers, when it should've been the minimum.

This bug would be witnessed if logger A (level `Verbose`) was installed with logger B (level `Assert`), whereas you'd only see assertion log messages (when you should've still seen all logs from logger A).