### PR TITLE
Revert "Update plugin android-publish to v0.23.1 (#229)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 [plugins]
 android-library = { id = "com.android.library", version = "8.0.0" }
-android-publish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }
+android-publish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
 atomicfu = { id = "kotlinx-atomicfu", version = "0.20.2" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.8.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }


### PR DESCRIPTION
This reverts commit 23821fa67e06168a21542b3b348f2aa1d5ecc737 as a workaround until https://github.com/vanniktech/gradle-maven-publish-plugin/issues/569 is fixed.