### PR TITLE
Define Maven group via Gradle script rather than `gradle.properties`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,8 @@ plugins {
 }
 
 allprojects {
+    group = "com.juul.tuulbox"
+
     repositories {
         google()
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,6 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 
-GROUP=com.juul.tuulbox
-
 POM_NAME=Tuulbox
 POM_DESCRIPTION=Toolbox of utilities/helpers for Kotlin development
 POM_INCEPTION_YEAR=2020


### PR DESCRIPTION
As a workaround for https://github.com/vanniktech/gradle-maven-publish-plugin/issues/569.