### PR TITLE
Lower JVM toolchain down to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/jdks
             ~/.konan
             ~/.android/build-cache
             ~/.android/cache

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,13 +17,14 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/jdks
             ~/.konan
             ~/.android/build-cache
             ~/.android/cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,14 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/jdks
             ~/.konan
             ~/.android/build-cache
             ~/.android/cache

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -11,7 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -11,13 +11,11 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()
-    android {
-        publishAllLibraryVariants()
-    }
+    android().publishAllLibraryVariants()
     macosX64()
     macosArm64()
     iosX64()
@@ -100,8 +98,8 @@ android {
     // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
     // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     compileSdk = libs.versions.android.compile.get().toInt()

--- a/encoding/build.gradle.kts
+++ b/encoding/build.gradle.kts
@@ -10,7 +10,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -10,7 +10,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 android-compile = "31"
 coroutines = "1.6.4"
 jacoco = "0.8.7"
+jvm-toolchain = "8"
 kotlin = "1.8.10"
 ktor = "2.3.0"
 

--- a/logging-android/build.gradle.kts
+++ b/logging-android/build.gradle.kts
@@ -8,11 +8,9 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    android {
-        publishAllLibraryVariants()
-    }
+    android().publishAllLibraryVariants()
 
     sourceSets {
         val commonMain by getting {
@@ -27,8 +25,8 @@ android {
     // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
     // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     compileSdk = libs.versions.android.compile.get().toInt()

--- a/logging-ktor-client/build.gradle.kts
+++ b/logging-ktor-client/build.gradle.kts
@@ -11,7 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/logging-test/build.gradle.kts
+++ b/logging-test/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -11,7 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,12 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Provides repositories for auto-downloading JVM toolchains.
+    // https://github.com/gradle/foojay-toolchains
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+}
+
 include(
     "collections",
     "coroutines",

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -11,7 +11,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser {
@@ -78,8 +78,8 @@ android {
     // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
     // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     compileSdk = libs.versions.android.compile.get().toInt()

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(11)
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     jvm()
     js().browser()


### PR DESCRIPTION
With #261, the JDK version used on CI was bumped up to `17` for compatibility with Android Gradle plugin (AGP) 8.0+; but the source and target compatibilities were also bumped in that PR.

This PR reverts the source and target compatibilities bumps so that library consumers aren't forced to bump their JDK versions (if they're still on JDK 8).