### PR TITLE
Deprecate hex functions in favor of stdlib support

### DIFF
--- a/encoding/src/commonMain/kotlin/HexString.kt
+++ b/encoding/src/commonMain/kotlin/HexString.kt
@@ -4,6 +4,16 @@ package com.juul.tuulbox.encoding
  * Provides basic [ByteArray] to hex [String] conversion. Modified version of kotlinx.serialization's `HexConverter`:
  * https://github.com/Kotlin/kotlinx.serialization/blob/43d5f7841fc744b072a636b712e194081456b5ba/formats/cbor/commonTest/src/kotlinx/serialization/HexConverter.kt
  */
+@Deprecated(
+    message = """Use Kotlin stdlib HexFormat support (available since 1.9.0), e.g. this.toHexString(HexFormat { bytes.byteSeparator = " "; bytes.bytePrefix = "0x"; upperCase = false } )""",
+    replaceWith = ReplaceWith(
+        expression = "this.toHexString(HexFormat.Default)",
+        imports = [
+            "kotlin.text.toHexString",
+            "kotlin.text.HexFormat",
+        ],
+    ),
+)
 public fun ByteArray.toHexString(
     separator: String? = null,
     prefix: String? = null,
@@ -26,6 +36,16 @@ public fun ByteArray.toHexString(
  * Provides basic hex [CharSequence] to [ByteArray] conversion. Modified version of kotlinx.serialization's `HexConverter`:
  * https://github.com/Kotlin/kotlinx.serialization/blob/43d5f7841fc744b072a636b712e194081456b5ba/formats/cbor/commonTest/src/kotlinx/serialization/HexConverter.kt
  */
+@Deprecated(
+    message = "Use Kotlin stdlib HexFormat support (available since 1.9.0).",
+    replaceWith = ReplaceWith(
+        expression = "this.hexToByteArray(HexFormat.Default)",
+        imports = [
+            "kotlin.text.hexToByteArray",
+            "kotlin.text.HexFormat",
+        ],
+    ),
+)
 public fun CharSequence.parseHex(): ByteArray {
     if (isEmpty()) return byteArrayOf()
     require(length % 2 == 0) { "Hex sequence must contain an even number of characters" }


### PR DESCRIPTION
Kotlin 1.9.0 stdlib introduced [New HexFormat class to format and parse hexadecimals](https://kotlinlang.org/docs/whatsnew19.html#new-hexformat-class-to-format-and-parse-hexadecimals). So, deprecating the hex functions that Tuulbox provides.

---

I tried a bunch of variations, but could not get `replaceWith` to work on the `toHexString` function:

![Screenshot 2023-07-08 at 1 37 59 AM](https://github.com/JuulLabs/tuulbox/assets/98017/e593a33d-aa71-40ae-ab84-c72fd03bbb55)

So, I included an example in the deprecation message.

---

`replaceWith` worked for `parseHex`: 🤷 

![Screenshot 2023-07-08 at 1 37 53 AM](https://github.com/JuulLabs/tuulbox/assets/98017/716bab3a-ce9e-4bf3-a1aa-46952b0bf0d1)