### PR TITLE
Use major-only version for `github-pages-deploy-action`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run: ./gradlew dokkaHtmlMultiModule
 
-      - uses: JamesIves/github-pages-deploy-action@v4.4.2
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/gh-pages
 


### PR DESCRIPTION
`github-pages-deploy-action` provides a major-only version tag for their action, which reduces the version churn.