### PR TITLE
Drop support for deprecated `iosArm32` target

### DIFF
--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -18,7 +18,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -57,10 +56,6 @@ kotlin {
         }
 
         val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -77,10 +76,6 @@ kotlin {
         }
 
         val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 

--- a/encoding/build.gradle.kts
+++ b/encoding/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 

--- a/functional/build.gradle.kts
+++ b/functional/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -57,10 +56,6 @@ kotlin {
         }
 
         val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 

--- a/logging-ktor-client/build.gradle.kts
+++ b/logging-ktor-client/build.gradle.kts
@@ -18,7 +18,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -85,14 +84,6 @@ kotlin {
         }
 
         val iosX64Test by getting {
-            dependsOn(appleTest)
-        }
-
-        val iosArm32Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Test by getting {
             dependsOn(appleTest)
         }
 

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -18,7 +18,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -62,10 +61,6 @@ kotlin {
         }
 
         val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosX64()
-    iosArm32()
     iosArm64()
     iosSimulatorArm64()
 
@@ -56,10 +55,6 @@ kotlin {
         }
 
         val iosX64Main by getting {
-            dependsOn(appleMain)
-        }
-
-        val iosArm32Main by getting {
             dependsOn(appleMain)
         }
 


### PR DESCRIPTION
https://kotl.in/native-targets-tiers