### PR TITLE
Remove npm publish step from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,6 @@ jobs:
         with:
           arguments: check
 
-      - name: check
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: packJsPackage
-
       - name: publish
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Tuulbox has no `packJsPackage` task, so the npm publish step was failing CI's publish action.