### PR TITLE
`AtomicMap` implementation

### DIFF
--- a/collections/api/collections.api
+++ b/collections/api/collections.api
@@ -1,5 +1,5 @@
 public final class com/juul/tuulbox/collections/AtomicMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
-	public final fun clear ()V
+	public fun clear ()V
 	public fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
 	public fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
 	public fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
@@ -7,33 +7,41 @@ public final class com/juul/tuulbox/collections/AtomicMap : java/util/Map, kotli
 	public fun containsValue (Ljava/lang/Object;)Z
 	public synthetic fun entrySet ()Ljava/util/Set;
 	public final fun entrySet ()Lkotlinx/collections/immutable/ImmutableSet;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun getAndMutate (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
 	public fun getEntries ()Lkotlinx/collections/immutable/ImmutableSet;
 	public final fun getFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getKeys ()Lkotlinx/collections/immutable/ImmutableSet;
-	public final fun getOrPut (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun getSize ()I
 	public final fun getSnapshot ()Lkotlinx/collections/immutable/ImmutableMap;
+	public final fun getState ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public fun getValues ()Lkotlinx/collections/immutable/ImmutableCollection;
+	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public synthetic fun keySet ()Ljava/util/Set;
 	public final fun keySet ()Lkotlinx/collections/immutable/ImmutableSet;
 	public fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
 	public final fun mutate (Lkotlin/jvm/functions/Function1;)V
-	public final fun mutateAndGet (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
-	public final fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun putAll (Ljava/util/Map;)V
+	public final fun mutateAndSnapshot (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
+	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putAll (Ljava/util/Map;)V
 	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
 	public fun replaceAll (Ljava/util/function/BiFunction;)V
-	public final fun set (Ljava/lang/Object;Ljava/lang/Object;)V
 	public final fun size ()I
+	public final fun snapshotAndMutate (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
+	public fun toString ()Ljava/lang/String;
 	public synthetic fun values ()Ljava/util/Collection;
 	public final fun values ()Lkotlinx/collections/immutable/ImmutableCollection;
+}
+
+public final class com/juul/tuulbox/collections/AtomicMapKt {
+	public static final fun atomicHashMapOf ([Lkotlin/Pair;)Lcom/juul/tuulbox/collections/AtomicMap;
+	public static final fun atomicMapOf ([Lkotlin/Pair;)Lcom/juul/tuulbox/collections/AtomicMap;
+	public static final fun getOrPut (Lcom/juul/tuulbox/collections/AtomicMap;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class com/juul/tuulbox/collections/SynchronizedMap : java/util/Map, kotlin/jvm/internal/markers/KMutableMap {

--- a/collections/api/collections.api
+++ b/collections/api/collections.api
@@ -1,3 +1,41 @@
+public final class com/juul/tuulbox/collections/AtomicMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public final fun clear ()V
+	public fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun containsKey (Ljava/lang/Object;)Z
+	public fun containsValue (Ljava/lang/Object;)Z
+	public synthetic fun entrySet ()Ljava/util/Set;
+	public final fun entrySet ()Lkotlinx/collections/immutable/ImmutableSet;
+	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getAndMutate (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
+	public fun getEntries ()Lkotlinx/collections/immutable/ImmutableSet;
+	public final fun getFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getKeys ()Lkotlinx/collections/immutable/ImmutableSet;
+	public final fun getOrPut (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getSize ()I
+	public final fun getSnapshot ()Lkotlinx/collections/immutable/ImmutableMap;
+	public fun getValues ()Lkotlinx/collections/immutable/ImmutableCollection;
+	public fun isEmpty ()Z
+	public synthetic fun keySet ()Ljava/util/Set;
+	public final fun keySet ()Lkotlinx/collections/immutable/ImmutableSet;
+	public fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public final fun mutate (Lkotlin/jvm/functions/Function1;)V
+	public final fun mutateAndGet (Lkotlin/jvm/functions/Function1;)Lkotlinx/collections/immutable/ImmutableMap;
+	public final fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun putAll (Ljava/util/Map;)V
+	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun set (Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun size ()I
+	public synthetic fun values ()Ljava/util/Collection;
+	public final fun values ()Lkotlinx/collections/immutable/ImmutableCollection;
+}
+
 public final class com/juul/tuulbox/collections/SynchronizedMap : java/util/Map, kotlin/jvm/internal/markers/KMutableMap {
 	public fun <init> ()V
 	public fun <init> (I)V

--- a/collections/api/collections.api
+++ b/collections/api/collections.api
@@ -1,4 +1,5 @@
 public final class com/juul/tuulbox/collections/AtomicMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Lkotlinx/collections/immutable/PersistentMap;)V
 	public fun clear ()V
 	public fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
 	public fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
@@ -10,10 +11,10 @@ public final class com/juul/tuulbox/collections/AtomicMap : java/util/Map, kotli
 	public fun equals (Ljava/lang/Object;)Z
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getEntries ()Lkotlinx/collections/immutable/ImmutableSet;
-	public final fun getFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getKeys ()Lkotlinx/collections/immutable/ImmutableSet;
 	public fun getSize ()I
 	public final fun getSnapshot ()Lkotlinx/collections/immutable/ImmutableMap;
+	public final fun getSnapshots ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getState ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public fun getValues ()Lkotlinx/collections/immutable/ImmutableCollection;
 	public fun hashCode ()I

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -22,7 +22,12 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting { }
+        val commonMain by getting {
+            dependencies {
+                api(libs.kotlinx.collections.immutable)
+                api(libs.kotlinx.coroutines.core)
+            }
+        }
 
         val commonTest by getting {
             dependencies {

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
+                implementation(libs.kotlinx.coroutines.test)
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -15,12 +15,12 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 
 /** Returns an [AtomicMap] that guarantees preservation of iteration order, but may be slower. */
-private fun <K, V> atomicMapOf(
+public fun <K, V> atomicMapOf(
     vararg pairs: Pair<K, V>,
 ): AtomicMap<K, V> = AtomicMap(persistentMapOf(*pairs))
 
 /** Returns an [AtomicMap] that does not guarantee preservation of iteration order, but may be faster. */
-private fun <K, V> atomicHashMapOf(
+public fun <K, V> atomicHashMapOf(
     vararg pairs: Pair<K, V>,
 ): AtomicMap<K, V> = AtomicMap(persistentHashMapOf(*pairs))
 
@@ -28,11 +28,12 @@ private fun <K, V> atomicHashMapOf(
  * A [Map] that allows for thread safe, atomic mutation. Returned collections such as [entries] and
  * [iterator] reference a [snapshot] of when they were accessed, and are not mutated when the map is.
  *
- * Provides methods similar to [MutableMap], although intentionally does not implement that interface
- * to discourage accidental use of methods that are not thread-safe (such as [MutableMap.getOrPut]).
+ * Although mutable, this class intentionally does not implement [MutableMap]. Mutation must use
+ * designated mutator functions ([mutate], [snapshotAndMutate], [mutateAndSnapshot]).
  */
 public class AtomicMap<K, V> private constructor(
-    private val state: MutableStateFlow<PersistentMap<K, V>>,
+    @PublishedApi
+    internal val state: MutableStateFlow<PersistentMap<K, V>>,
 ) : Map<K, V> {
 
     internal constructor(initial: PersistentMap<K, V>) : this(MutableStateFlow(initial))
@@ -67,54 +68,26 @@ public class AtomicMap<K, V> private constructor(
 
     override fun isEmpty(): Boolean = snapshot.isEmpty()
 
-    /** Equivalent to [MutableMap.clear]. */
-    public fun clear() {
-        state.update { it.clear() }
-    }
+    override fun equals(other: Any?): Boolean = snapshot == other
 
-    /** Equivalent to [MutableMap.remove]. */
-    public fun remove(key: K): V? =
-        state.getAndUpdate { it.remove(key) }[key]
+    override fun hashCode(): Int = snapshot.hashCode()
 
-    /** Equivalent to [MutableMap.putAll]. */
-    public fun putAll(from: Map<out K, V>) {
-        state.update { it.putAll(from) }
-    }
-
-    /** Equivalent to [MutableMap.put]. */
-    public fun put(key: K, value: V): V? =
-        state.getAndUpdate { it.put(key, value) }[key]
-
-    /** Equivalent to [MutableMap.set]. */
-    public operator fun set(key: K, value: V) {
-        state.update { it.put(key, value) }
-    }
-
-    /** Atomic version of [MutableMap.getOrPut]. [defaultValue] can be evaluated multiple times if a concurrent edit occurs. */
-    public fun getOrPut(key: K, defaultValue: () -> V): V {
-        val value = state.updateAndGet { map ->
-            if (key in map) {
-                map
-            } else {
-                map.put(key, defaultValue())
-            }
-        }[key]
-        // `as V` is used instead of `!!` or [checkNotNull] because it upcasts away from `null` when V is not nullable,
-        // but does not throw an exception when used with nullable V.
-        @Suppress("UNCHECKED_CAST")
-        return value as V
-    }
+    override fun toString(): String = snapshot.toString()
 
     /** Mutates this map atomically. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
-    public fun mutate(mutator: MutableMap<K, V>.() -> Unit) {
+    public inline fun mutate(mutator: MutableMap<K, V>.() -> Unit) {
         state.update { it.mutate(mutator) }
     }
 
     /** Mutates this map atomically and returns the previous [snapshot]. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
-    public fun getAndMutate(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
+    public inline fun snapshotAndMutate(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
         state.getAndUpdate { it.mutate(mutator) }
 
     /** Mutates this map atomically and returns the new [snapshot]. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
-    public fun mutateAndGet(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
+    public inline fun mutateAndSnapshot(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
         state.updateAndGet { it.mutate(mutator) }
 }
+
+/** Atomic version of [MutableMap.getOrPut]. [defaultValue] can be evaluated multiple times if a concurrent edit occurs. */
+public inline fun <K, V> AtomicMap<K, V>.getOrPut(key: K, defaultValue: () -> V): V =
+    mutateAndSnapshot { getOrPut(key, defaultValue) }.getValue(key)

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -1,0 +1,116 @@
+package com.juul.tuulbox.collections
+
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
+
+/** Returns an [AtomicMap] that guarantees preservation of iteration order, but may be slower. */
+private fun <K, V> atomicMapOf(
+    vararg pairs: Pair<K, V>,
+): AtomicMap<K, V> = AtomicMap(persistentMapOf(*pairs))
+
+/** Returns an [AtomicMap] that does not guarantee preservation of iteration order, but may be faster. */
+private fun <K, V> atomicHashMapOf(
+    vararg pairs: Pair<K, V>,
+): AtomicMap<K, V> = AtomicMap(persistentHashMapOf(*pairs))
+
+/**
+ * A [Map] that allows for thread safe, atomic mutation. Returned collections such as [entries] and
+ * [iterator] reference a [snapshot] of when they were accessed, and are not mutated when the map is.
+ *
+ * Provides methods similar to [MutableMap], although intentionally does not implement that interface
+ * to discourage accidental use of methods that are not thread-safe (such as [MutableMap.getOrPut]).
+ */
+public class AtomicMap<K, V> private constructor(
+    private val state: MutableStateFlow<PersistentMap<K, V>>,
+) : Map<K, V> {
+
+    internal constructor(initial: PersistentMap<K, V>) : this(MutableStateFlow(initial))
+
+    /** Returns this map as a [StateFlow]. Each call to [put], [mutate], etc will cause a new emit on this flow. */
+    public val flow: StateFlow<ImmutableMap<K, V>> = state.asStateFlow()
+
+    /**
+     * Returns the current value of this map as an [immutable][ImmutableMap] snapshot.
+     *
+     * This operation is non-copying and efficient.
+     */
+    public val snapshot: ImmutableMap<K, V> get() = state.value
+
+    override val size: Int
+        get() = snapshot.size
+
+    override val entries: Set<Map.Entry<K, V>>
+        get() = snapshot.entries
+
+    override val keys: Set<K>
+        get() = snapshot.keys
+
+    override val values: Collection<V>
+        get() = snapshot.values
+
+    override fun containsKey(key: K): Boolean = snapshot.containsKey(key)
+
+    override fun containsValue(value: V): Boolean = snapshot.containsValue(value)
+
+    override fun get(key: K): V? = snapshot[key]
+
+    override fun isEmpty(): Boolean = snapshot.isEmpty()
+
+    /** Equivalent to [MutableMap.clear]. */
+    public fun clear() {
+        state.update { it.clear() }
+    }
+
+    /** Equivalent to [MutableMap.remove]. */
+    public fun remove(key: K): V? =
+        state.getAndUpdate { it.remove(key) }[key]
+
+    /** Equivalent to [MutableMap.putAll]. */
+    public fun putAll(from: Map<out K, V>) {
+        state.update { it.putAll(from) }
+    }
+
+    /** Equivalent to [MutableMap.put]. */
+    public fun put(key: K, value: V): V? =
+        state.getAndUpdate { it.put(key, value) }[key]
+
+    /** Equivalent to [MutableMap.set]. */
+    public operator fun set(key: K, value: V) {
+        state.update { it.put(key, value) }
+    }
+
+    /** Atomic version of [MutableMap.getOrPut]. [defaultValue] can be evaluated multiple times if a concurrent edit occurs. */
+    // `as V` is used instead of `!!` or [checkNotNull] because it upcasts away from `null` when V is not nullable, but does not
+    // throw an exception when used with nullable V.
+    @Suppress("UNCHECKED_CAST")
+    public fun getOrPut(key: K, defaultValue: () -> V): V =
+        state.updateAndGet { map ->
+            if (key in map) {
+                map
+            } else {
+                map.put(key, defaultValue())
+            }
+        }[key] as V
+
+    /** Mutates this map atomically. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
+    public fun mutate(mutator: MutableMap<K, V>.() -> Unit) {
+        state.update { it.mutate(mutator) }
+    }
+
+    /** Mutates this map atomically and returns the previous map. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
+    public fun getAndMutate(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
+        state.getAndUpdate { it.mutate(mutator) }
+
+    /** Mutates this map atomically and returns the new map. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
+    public fun mutateAndGet(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
+        state.updateAndGet { it.mutate(mutator) }
+}

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -91,17 +91,19 @@ public class AtomicMap<K, V> private constructor(
     }
 
     /** Atomic version of [MutableMap.getOrPut]. [defaultValue] can be evaluated multiple times if a concurrent edit occurs. */
-    // `as V` is used instead of `!!` or [checkNotNull] because it upcasts away from `null` when V is not nullable, but does not
-    // throw an exception when used with nullable V.
-    @Suppress("UNCHECKED_CAST")
-    public fun getOrPut(key: K, defaultValue: () -> V): V =
-        state.updateAndGet { map ->
+    public fun getOrPut(key: K, defaultValue: () -> V): V {
+        val value = state.updateAndGet { map ->
             if (key in map) {
                 map
             } else {
                 map.put(key, defaultValue())
             }
-        }[key] as V
+        }[key]
+        // `as V` is used instead of `!!` or [checkNotNull] because it upcasts away from `null` when V is not nullable,
+        // but does not throw an exception when used with nullable V.
+        @Suppress("UNCHECKED_CAST")
+        return value as V
+    }
 
     /** Mutates this map atomically. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
     public fun mutate(mutator: MutableMap<K, V>.() -> Unit) {

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -1,6 +1,8 @@
 package com.juul.tuulbox.collections
 
+import kotlinx.collections.immutable.ImmutableCollection
 import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentHashMapOf
@@ -48,13 +50,13 @@ public class AtomicMap<K, V> private constructor(
     override val size: Int
         get() = snapshot.size
 
-    override val entries: Set<Map.Entry<K, V>>
+    override val entries: ImmutableSet<Map.Entry<K, V>>
         get() = snapshot.entries
 
-    override val keys: Set<K>
+    override val keys: ImmutableSet<K>
         get() = snapshot.keys
 
-    override val values: Collection<V>
+    override val values: ImmutableCollection<V>
         get() = snapshot.values
 
     override fun containsKey(key: K): Boolean = snapshot.containsKey(key)
@@ -106,11 +108,11 @@ public class AtomicMap<K, V> private constructor(
         state.update { it.mutate(mutator) }
     }
 
-    /** Mutates this map atomically and returns the previous map. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
+    /** Mutates this map atomically and returns the previous [snapshot]. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
     public fun getAndMutate(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
         state.getAndUpdate { it.mutate(mutator) }
 
-    /** Mutates this map atomically and returns the new map. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
+    /** Mutates this map atomically and returns the new [snapshot]. [mutator] can be evaluated multiple times if a concurrent edit occurs. */
     public fun mutateAndGet(mutator: MutableMap<K, V>.() -> Unit): ImmutableMap<K, V> =
         state.updateAndGet { it.mutate(mutator) }
 }

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -38,7 +38,7 @@ public class AtomicMap<K, V> private constructor(
 
     internal constructor(initial: PersistentMap<K, V>) : this(MutableStateFlow(initial))
 
-    /** Returns this map as a [StateFlow]. Each call to [put], [mutate], etc will cause a new emit on this flow. */
+    /** Returns this map as a [StateFlow]. Each mutation will cause a new emit on this flow. */
     public val flow: StateFlow<ImmutableMap<K, V>> = state.asStateFlow()
 
     /**

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -46,7 +46,8 @@ public class AtomicMap<K, V> private constructor(
      *
      * This operation is non-copying and efficient.
      */
-    public val snapshot: ImmutableMap<K, V> get() = state.value
+    public val snapshot: ImmutableMap<K, V>
+        get() = state.value
 
     override val size: Int
         get() = snapshot.size

--- a/collections/src/commonMain/kotlin/AtomicMap.kt
+++ b/collections/src/commonMain/kotlin/AtomicMap.kt
@@ -36,10 +36,11 @@ public class AtomicMap<K, V> private constructor(
     internal val state: MutableStateFlow<PersistentMap<K, V>>,
 ) : Map<K, V> {
 
-    internal constructor(initial: PersistentMap<K, V>) : this(MutableStateFlow(initial))
+    /** Construct an [AtomicMap] with [initial] mappings. */
+    public constructor(initial: PersistentMap<K, V>) : this(MutableStateFlow(initial))
 
-    /** Returns this map as a [StateFlow]. Each mutation will cause a new emit on this flow. */
-    public val flow: StateFlow<ImmutableMap<K, V>> = state.asStateFlow()
+    /** Returns this map as a [StateFlow]. Each mutation will cause a new emission on this flow. */
+    public val snapshots: StateFlow<ImmutableMap<K, V>> = state.asStateFlow()
 
     /**
      * Returns the current value of this map as an [immutable][ImmutableMap] snapshot.
@@ -47,7 +48,7 @@ public class AtomicMap<K, V> private constructor(
      * This operation is non-copying and efficient.
      */
     public val snapshot: ImmutableMap<K, V>
-        get() = state.value
+        get() = snapshots.value
 
     override val size: Int
         get() = snapshot.size

--- a/collections/src/commonMain/kotlin/SynchronizedMap.kt
+++ b/collections/src/commonMain/kotlin/SynchronizedMap.kt
@@ -5,14 +5,26 @@ import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 
 /** Returns an empty new [SynchronizedMap]. */
+@Deprecated(
+    "Prefer using atomicMapOf instead. SynchronizedMap does not play nicely with coroutines.",
+    ReplaceWith("atomicMapOf", "com.juul.tuulbox.collections.atomicMapOf"),
+)
 public fun <K, V> synchronizedMapOf(): SynchronizedMap<K, V> =
     SynchronizedMap(linkedMapOf())
 
 /** Returns a new [SynchronizedMap] with the specified contents. */
+@Deprecated(
+    "Prefer using atomicMapOf instead. SynchronizedMap does not play nicely with coroutines.",
+    ReplaceWith("atomicMapOf", "com.juul.tuulbox.collections.atomicMapOf"),
+)
 public fun <K, V> synchronizedMapOf(vararg pairs: Pair<K, V>): SynchronizedMap<K, V> =
     SynchronizedMap(linkedMapOf(*pairs))
 
 /** A [MutableMap] where all reads and writes are protected by a [ReentrantLock]. */
+@Deprecated(
+    "Prefer using AtomicMap instead. SynchronizedMap does not play nicely with coroutines.",
+    ReplaceWith("AtomicMap", "com.juul.tuulbox.collections.AtomicMap"),
+)
 public class SynchronizedMap<K, V> internal constructor(
     private val inner: LinkedHashMap<K, V>,
 ) : MutableMap<K, V> {

--- a/collections/src/commonTest/kotlin/AtomicMapTests.kt
+++ b/collections/src/commonTest/kotlin/AtomicMapTests.kt
@@ -1,5 +1,6 @@
 package com.juul.tuulbox.collections
 
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -11,7 +12,7 @@ public class AtomicMapTests {
 
     @Test
     public fun atomicMap_concurrentMutateBlocks_doesNotLoseWrites() = runTest {
-        val actual = atomicMapOf<String, Int>()
+        val actual = AtomicMap<String, Int>(persistentMapOf())
         (1..10).map {
             launch(Dispatchers.Default) {
                 for (i in 0 until 500) {
@@ -21,5 +22,23 @@ public class AtomicMapTests {
         }.joinAll()
 
         assertEquals(mapOf("count" to 5_000), actual)
+    }
+
+    @Test
+    public fun atomicMap_snapshotAndMutate_returnsPreviousSnapshot() = runTest {
+        val atomic = AtomicMap<Int, Int>(persistentMapOf())
+        val actual = atomic.snapshotAndMutate {
+            put(0, 0)
+        }
+        assertEquals(emptyMap(), actual)
+    }
+
+    @Test
+    public fun atomicMap_mutateAndSnapshot_returnsNewSnapshot() = runTest {
+        val atomic = AtomicMap<Int, Int>(persistentMapOf())
+        val actual = atomic.mutateAndSnapshot {
+            put(0, 0)
+        }
+        assertEquals(mapOf(0 to 0), actual)
     }
 }

--- a/collections/src/commonTest/kotlin/AtomicMapTests.kt
+++ b/collections/src/commonTest/kotlin/AtomicMapTests.kt
@@ -1,0 +1,25 @@
+package com.juul.tuulbox.collections
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+public class AtomicMapTests {
+
+    @Test
+    public fun atomicMap_concurrentMutateBlocks_doesNotLoseWrites() = runTest {
+        val actual = atomicMapOf<String, Int>()
+        (1..10).map {
+            launch(Dispatchers.Default) {
+                for (i in 0 until 500) {
+                    actual.mutate { this["count"] = (this["count"] ?: 0) + 1 }
+                }
+            }
+        }.joinAll()
+
+        assertEquals(mapOf("count" to 5_000), actual)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ktor = "2.3.7"
 [libraries]
 androidx-core = { module = "androidx.core:core", version = "1.12.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.7" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
Reentrant lock had some problems. Backing via `MutableStateFlow` has been pretty flawless