### PR TITLE
Simplify `binary-compatibility-validator` setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,14 @@ buildscript {
         google()
         mavenCentral()
     }
+    dependencies {
+        classpath(libs.atomicfu)
+    }
 }
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false
-    alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.api)
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ktor = "2.3.9"
 [libraries]
 androidx-core = { module = "androidx.core:core", version = "1.12.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version = "0.23.1" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.7" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -21,7 +22,6 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.23.1" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.14.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.14.0" }
+api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.2.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,9 +12,6 @@ pluginManagement {
                 "binary-compatibility-validator" ->
                     useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
 
-                "kotlinx-atomicfu" ->
-                    useModule("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${requested.version}")
-
                 else -> when (requested.id.namespace) {
                     "com.android" ->
                         useModule("com.android.tools.build:gradle:${requested.version}")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,20 +5,6 @@ pluginManagement {
         google()
         gradlePluginPortal()
     }
-
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "binary-compatibility-validator" ->
-                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-
-                else -> when (requested.id.namespace) {
-                    "com.android" ->
-                        useModule("com.android.tools.build:gradle:${requested.version}")
-                }
-            }
-        }
-    }
 }
 
 plugins {


### PR DESCRIPTION
Updates configuration to more closely match [official setup instructions](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#setup) (by not configuring/using a shorthand name for the plugin — in other words: no longer using `resolutionStrategy`).