### PR TITLE
Mark `BroadcastReceiver.onReceive` parameters as non-`null`

### DIFF
--- a/coroutines/src/androidMain/kotlin/flow/BroadcastReceiverFlow.kt
+++ b/coroutines/src/androidMain/kotlin/flow/BroadcastReceiverFlow.kt
@@ -12,16 +12,13 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 public fun broadcastReceiverFlow(
     intentFilter: IntentFilter,
     @RegisterReceiverFlags flags: Int = RECEIVER_NOT_EXPORTED,
 ): Flow<Intent> = callbackFlow {
     val broadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent != null) {
-                trySend(intent)
-            }
+        override fun onReceive(context: Context, intent: Intent) {
+            trySend(intent)
         }
     }
     ContextCompat.registerReceiver(applicationContext, broadcastReceiver, intentFilter, flags)


### PR DESCRIPTION
[Android examples] show parameters as non-`null`; additionally, per "can ever the intent received by a BroadcastReceiver be null?" on [Stackoverflow]:

> `onReceive` in a `BroadcastReceiver` is triggered by an `Intent` with an action that it's registered to. So without `Intent` being an instance of `Intent` and not `null`, the `onReceive` method would never get called.

It would also be better to throw an NPE (and be made aware of a bug) than for it to fail silently (and never emit a value).

[Android examples]: https://developer.android.com/develop/background-work/background-tasks/broadcasts#receiving-broadcasts
[Stackoverflow]: https://stackoverflow.com/a/17535679