### PR TITLE
Use macOS variant of `EnricoMi/publish-unit-test-result-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
 
       - run: ./gradlew jacocoTestReport
 
-      - uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      - uses: EnricoMi/publish-unit-test-result-action/macos@v2
         with:
+          check_run: false
           junit_files: '**/build/test-results/**/*.xml'
-          report_individual_runs: 'true'
+          report_individual_runs: true
 
       - uses: codecov/codecov-action@v4


### PR DESCRIPTION
`EnricoMi/publish-unit-test-result-action/composite` has been deprecated.