### PR TITLE
Disable Android `GradleDependency` lint check

### DIFF
--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -103,5 +103,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -81,5 +81,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }


### PR DESCRIPTION
Outdated dependencies should not fail builds/CI checks.