### PR TITLE
Use `CENTRAL_PORTAL` Sonatype host for publication

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.parallel=true
 # Publication configuration
 # https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties
 
-SONATYPE_HOST=DEFAULT
+SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 


### PR DESCRIPTION
Updates Sonatype host per [`gradle-maven-publish-plugin` release notes](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.33.0).