### PR TITLE
Pin setup-chrome v2 to latest snapshot for macOS Karma headless tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - uses: browser-actions/setup-chrome@v2
         id: setup-chrome
+        with:
+          # Use the Chromium snapshot installer (v1's default behavior) instead
+          # of v2's `stable` default. The `stable` channel installs Chrome for
+          # Testing on macOS but strips the `.app` bundle wrapper from the
+          # cached install, which breaks headless launches under Karma even
+          # though `--version` succeeds. The `latest` snapshot installer
+          # preserves `Chromium.app/Contents/MacOS/Chromium`.
+          chrome-version: latest
 
       - run: ./gradlew assemble
       - run: ./gradlew check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,14 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - uses: browser-actions/setup-chrome@v2
         id: setup-chrome
+        with:
+          # Use the Chromium snapshot installer (v1's default behavior) instead
+          # of v2's `stable` default. The `stable` channel installs Chrome for
+          # Testing on macOS but strips the `.app` bundle wrapper from the
+          # cached install, which breaks headless launches under Karma even
+          # though `--version` succeeds. The `latest` snapshot installer
+          # preserves `Chromium.app/Contents/MacOS/Chromium`.
+          chrome-version: latest
 
       - run: ./gradlew check
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Targets the renovate branch for #477 to fix CI.

## Problem

After bumping `browser-actions/setup-chrome` from v1 to v2 in #477, the `build` job on `macos-15` started failing with:

```
ChromeHeadless has not captured in 60000 ms, killing.
ChromeHeadless failed 2 times (timeout). Giving up.
java.lang.IllegalStateException: Errors occurred during launch of browser for testing.
```

across `:collections:jsBrowserTest`, `:encoding:jsBrowserTest`, and `:coroutines:jsBrowserTest`.

## Root cause

`browser-actions/setup-chrome@v2` changed the default install from a Chromium snapshot (v1) to the `stable` channel of Chrome for Testing. On macOS, the v2 installer for the `stable` channel ([`channel_macos.ts`](https://github.com/browser-actions/setup-chrome/blob/master/src/channel_macos.ts)) caches **only the contents of the `.app` bundle**, not the bundle itself:

```ts
const extAppRoot = path.join(
  extPath,
  `chrome-${this.versionResolver.platformString}`,
  "Google Chrome for Testing.app",
);
const root = await cache.cacheDir(extAppRoot, "chrome", version);
return { root, bin: "Contents/MacOS/Google Chrome for Testing" };
```

That produces a `chrome-path` like `/Users/runner/hostedtoolcache/setup-chrome/chrome/stable/arm64/Contents/MacOS/Google Chrome for Testing` — the `Google Chrome for Testing.app` directory is gone. The action's own `--version` smoke test succeeds, but a real headless launch by Karma cannot resolve the framework/resource lookups that depend on the `.app` bundle structure, so Chrome never connects back to Karma and the run times out.

The previous CI run on `main` (with v1) installed a Chromium snapshot at `.../Chromium.app/Contents/MacOS/Chromium` with the `.app` wrapper preserved, which Karma launches happily.

## Fix

Pass `chrome-version: latest` to the v2 action in both `ci.yml` and `publish.yml`. That routes through `LatestInstaller` → `SnapshotInstaller`, which preserves `Chromium.app/Contents/MacOS/Chromium` — matching v1's default behavior and what Karma's `ChromeHeadless` launcher expects on macOS.

A comment is left in each workflow explaining why the explicit `chrome-version` is necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5a13e46-6735-4d99-8549-1e8781b5d3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5a13e46-6735-4d99-8549-1e8781b5d3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

