### PR TITLE
Update android-compile version to `37`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-compile = "36"
+android-compile = "37"
 coroutines = "1.11.0"
 jacoco = "0.8.7"
 jvm-toolchain = "11"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version-catalog constant change with no application logic; typical low-risk build/SDK alignment that may surface compile-time API deprecations or toolchain warnings.
> 
> **Overview**
> Bumps the shared **`android-compile`** version catalog entry from **36** to **37** in `gradle/libs.versions.toml`, aligning the project’s Android compile SDK with API level 37 wherever that version ref is used in the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75e437f832fed7da34a8c8fbf695a713db7de82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->