### PR TITLE
Fix Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ bitSet.asPrimitive() // 1099511627776L
 
 ### Gradle
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.tuulbox/coroutines/badge.svg)](https://search.maven.org/search?q=g:com.juul.tuulbox)
+[![Maven Central](https://img.shields.io/maven-central/v/com.juul.tuulbox/coroutines)](https://central.sonatype.com/search?namespace=com.juul.tuulbox)
 
 Tuulbox can be configured via Gradle Kotlin DSL as follows:
 


### PR DESCRIPTION
`maven-badges.herokuapp` seems to be broken. Replaced with shields.io.

Rendered markdown can be viewed [here](https://github.com/JuulLabs/tuulbox/tree/twyatt/maven-central-badge#gradle).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change; no runtime or build impact.
> 
> **Overview**
> **Replaces the broken Maven Central badge** in the Setup → Gradle section of `README.md`.
> 
> The image URL now uses **shields.io** (`maven-central/v/com.juul.tuulbox/coroutines`) instead of `maven-badges.herokuapp.com`. The badge link target is updated to **Sonatype Central** (`central.sonatype.com` namespace search) instead of the old Maven Central search URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93836b71fd90717e70600e15e4e1c50a8b37b77d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->