### PR TITLE
Downgrade `androidx.core:core` to v1.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "2.4.10"
 ktor = "3.5.1"
 
 [libraries]
-androidx-core = { module = "androidx.core:core", version = "1.19.0" }
+androidx-core = { module = "androidx.core:core", version = "1.16.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2.0" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.5.1" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,20 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+    ':disableDependencyDashboard',
+    ':disableRateLimiting',
+  ],
+  packageRules: [
+    // Pin `androidx.core:core[-ktx]` to 1.16.0. Newer releases (1.17.0+) bump the required Android
+    // Gradle plugin version, which would force consumers onto AGP 9.
+    // See https://github.com/JuulLabs/kable/issues/1206.
+    {
+      matchPackageNames: [
+        'androidx.core:core',
+        'androidx.core:core-ktx',
+      ],
+      allowedVersions: '1.16.0',
+    },
+  ],
+}


### PR DESCRIPTION
Newer versions of `androidx.core:core` impose AGP version requirements on consumers. We don't leverage anything in the newer versions, so it is best to pin us to an older version so we don't impose AGP version requirements downstream (https://github.com/JuulLabs/kable/issues/1206).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin and Renovate config only; no runtime or API logic changes.
> 
> **Overview**
> Pins **`androidx.core:core`** to **1.16.0** in `gradle/libs.versions.toml` (down from 1.19.0) so Kable does not pull in releases that require a newer Android Gradle Plugin for consumers.
> 
> Adds **`renovate.json5`** with recommended Renovate settings and a **package rule** that only allows **1.16.0** for `androidx.core:core` and `androidx.core:core-ktx`, documented as avoiding **1.17.0+** AGP requirements (see issue #1206).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa6110f40e708eb6f0d2fb5cb88bdb8793e9522. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->