### PR TITLE
Relax consumer Android SDK requirement

### DIFF
--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -19,6 +19,9 @@ kotlin {
         namespace = "com.juul.tuulbox.coroutines"
         compileSdk = libs.versions.android.compile.get().toInt()
         minSdk = 16
+        aarMetadata {
+            minCompileSdk = 16
+        }
 
         androidResources { enable = true }
 

--- a/temporal/build.gradle.kts
+++ b/temporal/build.gradle.kts
@@ -25,6 +25,9 @@ kotlin {
         namespace = "com.juul.tuulbox.temporal"
         compileSdk = libs.versions.android.compile.get().toInt()
         minSdk = 16
+        aarMetadata {
+            minCompileSdk = 16
+        }
 
         withHostTest {}
 


### PR DESCRIPTION
To proactively fix the issue here (before it is reported) that was reported for Kable: https://github.com/JuulLabs/kable/issues/1206

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gradle-only AAR metadata in two modules; no application logic or API surface changes.
> 
> **Overview**
> **Relaxes the minimum `compileSdk` that Android apps must use** when depending on the published `coroutines` and `temporal` AARs, by adding `aarMetadata { minCompileSdk = 16 }` in each module’s `android { }` block (alongside existing `minSdk = 16`).
> 
> This is build/publish metadata only—no Kotlin or runtime behavior changes—and mirrors the fix discussed for downstream consumers (e.g. Kable) that were blocked by stricter AAR metadata requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c1c95674e87dd5598d4bfa43693053de0cac4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->