### PR TITLE
Migrate Dokka to V2 mode

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v6
 
-      - run: ./gradlew dokkaHtmlMultiModule
+      - run: ./gradlew dokkaGenerate
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: build/gh-pages
+          folder: build/dokka/html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,15 @@ plugins {
     alias(libs.plugins.api)
 }
 
+dependencies {
+    dokka(projects.collections)
+    dokka(projects.coroutines)
+    dokka(projects.functional)
+    dokka(projects.temporal)
+    dokka(projects.test)
+    dokka(projects.encoding)
+}
+
 allprojects {
     group = "com.juul.tuulbox"
 
@@ -37,10 +46,6 @@ allprojects {
             toolVersion = libs.versions.jacoco.get()
         }
     }
-}
-
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.fileProvider(layout.buildDirectory.file("gh-pages").map { it.asFile })
 }
 
 fun Project.withPluginWhenEvaluated(plugin: String, action: Project.() -> Unit) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build and CI-only documentation pipeline changes with no runtime or application logic impact.
> 
> **Overview**
> **Migrates API docs generation from Dokka’s legacy multi-module HTML task to Dokka v2.**
> 
> The root Gradle build now registers each library module (`collections`, `coroutines`, `functional`, `temporal`, `test`, `encoding`) via the `dokka(...)` dependency API and relies on **`dokkaGenerate`** instead of **`dokkaHtmlMultiModule`**. The old task that redirected HTML output to `build/gh-pages` is removed in favor of Dokka v2’s default **`build/dokka/html`** layout.
> 
> The **GitHub Pages** workflow runs `./gradlew dokkaGenerate` and deploys **`build/dokka/html`**, matching the new output path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5b4398e4101c49d1810de5e0a6aa6b97470707. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->